### PR TITLE
feat(ballistics): time-of-flight projectile simulation with drag and drop

### DIFF
--- a/Classes/Combat/ballistic_projectile_system.gd
+++ b/Classes/Combat/ballistic_projectile_system.gd
@@ -1,0 +1,179 @@
+class_name BallisticProjectileSystem
+extends Node
+
+# ============================================================
+# 弹道模拟系统（P2 — 飞行时间弹丸）
+# 功能：管理所有在飞弹丸的逐物理帧模拟：
+#       重力下坠 + 二次空气阻力（由弹道系数 BC 推导）+ 分段射线命中检测。
+#       命中时按"落点实时速度"计算动能 → 远距离伤害自然衰减。
+# 用法：BaseWeapon 通过 get_or_create(get_tree()) 获取共享实例，
+#       调用 spawn(...) 发射一发弹丸。全部弹丸在单个 Node 中批量
+#       模拟（数组而非每弹一个 Node，避免节点开销）。
+# 兼容：命中解析仍走 HitResolver.resolve() → DamageInfo →
+#       HealthSystem.apply_damage()，医疗系统 API 无任何变化。
+# ============================================================
+
+## 弹丸最大飞行距离（米），超出后移除
+const MAX_RANGE_M: float = 2000.0
+## 弹丸最大飞行时间（秒），兜底防泄漏
+const MAX_FLIGHT_TIME_S: float = 8.0
+## 低于此速度（m/s）视为失能弹头，直接移除（KE 已不足以造成有效伤口）
+const MIN_SPEED_MPS: float = 40.0
+## 同时在飞弹丸上限，超出时丢弃最旧的（防异常连发泄漏）
+const MAX_ACTIVE_BULLETS: int = 256
+
+## 射线碰撞掩码：layer 1（环境，阻挡弹丸）+ layer 2（hitbox/布娃娃骨骼）
+const HIT_MASK: int = 1 | 2
+
+static var _instance: BallisticProjectileSystem = null
+
+## 在飞弹丸列表。每项为 Dictionary：
+##   position: Vector3      当前位置（世界空间）
+##   velocity: Vector3      当前速度向量（m/s）
+##   mass_kg: float         弹头质量
+##   bc: float              弹道系数（G1 近似）
+##   source: WeakRef        开火武器（可能已被释放，命中时解引用）
+##   exclude: Array[RID]    射手自身的碰撞体排除列表
+##   world: World3D         发射时所在物理世界
+##   traveled: float        累计飞行距离（米）
+##   time: float            累计飞行时间（秒）
+var _bullets: Array[Dictionary] = []
+
+var _gravity: float = 9.8
+
+
+## 获取（或惰性创建并挂到场景根的）共享实例
+static func get_or_create(tree: SceneTree) -> BallisticProjectileSystem:
+	if is_instance_valid(_instance):
+		return _instance
+	_instance = BallisticProjectileSystem.new()
+	_instance.name = "BallisticProjectileSystem"
+	tree.root.add_child(_instance)
+	return _instance
+
+
+func _ready() -> void:
+	_gravity = float(ProjectSettings.get_setting("physics/3d/default_gravity", 9.8))
+	GlobalLogger.info("Ballistics", "BallisticProjectileSystem ready (gravity=%.2f m/s²)" % _gravity)
+
+
+## 发射一发模拟弹丸
+## origin: 弹丸起点（枪口世界坐标）
+## direction: 初始飞行方向（无需归一化）
+## config: 武器配置（bullet_mass_g / muzzle_velocity / ballistic_coefficient）
+## source: 开火的武器节点（DamageInfo.source；以 WeakRef 存储防悬空）
+## exclude: 射手自身 RID（胶囊体 + hitbox），防自伤
+## world: 发射时的 World3D
+func spawn(
+	origin: Vector3,
+	direction: Vector3,
+	config: WeaponConfig,
+	source: Node,
+	exclude: Array[RID],
+	world: World3D
+) -> void:
+	if not world:
+		GlobalLogger.warn("Ballistics", "spawn() without World3D, bullet dropped")
+		return
+	if _bullets.size() >= MAX_ACTIVE_BULLETS:
+		_bullets.pop_front()
+		GlobalLogger.warn("Ballistics", "Active bullet cap reached, oldest bullet dropped")
+
+	_bullets.append({
+		"position": origin,
+		"velocity": direction.normalized() * config.muzzle_velocity,
+		"mass_kg": config.bullet_mass_g / 1000.0,
+		"bc": config.ballistic_coefficient,
+		"source": weakref(source),
+		"exclude": exclude,
+		"world": world,
+		"traveled": 0.0,
+		"time": 0.0,
+	})
+
+
+func _physics_process(delta: float) -> void:
+	if _bullets.is_empty():
+		return
+	# 倒序遍历，命中/超程的弹丸就地移除
+	for i in range(_bullets.size() - 1, -1, -1):
+		if not _step_bullet(_bullets[i], delta):
+			_bullets.remove_at(i)
+
+
+## 推进单发弹丸一个物理帧。[返回] false = 弹丸应被移除
+func _step_bullet(b: Dictionary, delta: float) -> bool:
+	var world: World3D = b["world"]
+	if not is_instance_valid(world):
+		return false
+
+	# 1. 空气阻力：二次阻力 dv/dt = −k·v²，k 由 BC 推导（见 Ballistics.drag_factor）
+	var velocity: Vector3 = b["velocity"]
+	var speed: float = velocity.length()
+	var new_speed: float = maxf(speed - Ballistics.drag_decel(speed, b["bc"]) * delta, 0.0)
+	if new_speed < MIN_SPEED_MPS:
+		return false
+
+	# 2. 半隐式欧拉积分：先更新速度（阻力 + 重力），再位移
+	velocity = velocity * (new_speed / speed) + Vector3.DOWN * _gravity * delta
+	var next_position: Vector3 = b["position"] + velocity * delta
+
+	# 3. 分段射线检测（本帧扫过的线段；900 m/s @ 60 Hz ≈ 15 m/帧）
+	var query := PhysicsRayQueryParameters3D.create(
+		b["position"], next_position, HIT_MASK, b["exclude"]
+	)
+	query.collide_with_areas = true
+	query.collide_with_bodies = true
+	var space_state := world.direct_space_state
+	if not space_state:
+		return false
+	var result := space_state.intersect_ray(query)
+
+	if not result.is_empty():
+		_on_bullet_hit(b, result, velocity)
+		return false
+
+	# 4. 未命中：推进状态，检查超程/超时
+	b["velocity"] = velocity
+	b["position"] = next_position
+	b["traveled"] = b["traveled"] + new_speed * delta
+	b["time"] = b["time"] + delta
+	return b["traveled"] < MAX_RANGE_M and b["time"] < MAX_FLIGHT_TIME_S
+
+
+## 命中处理：按落点实时速度计算动能，经 HitResolver 构建 DamageInfo 提交医疗系统。
+## 命中环境（无 BasePlayer 祖先）时弹丸静默终止——这就是墙体阻挡。
+func _on_bullet_hit(b: Dictionary, ray_result: Dictionary, velocity: Vector3) -> void:
+	var collider = ray_result.get("collider", null)
+	if not collider:
+		return
+
+	var player_node := Projectile.find_player(collider)
+	if not player_node:
+		return
+	if not player_node.has_node("HealthSystem"):
+		GlobalLogger.warn("Ballistics", "Hit player has no HealthSystem")
+		return
+
+	# 落点动能：速度已含全程阻力/重力衰减 → 远距离命中伤害自然降低
+	var impact_speed: float = velocity.length()
+	var energy: float = Ballistics.kinetic_energy(b["mass_kg"], impact_speed)
+
+	var source_ref: WeakRef = b["source"]
+	var source: Node = source_ref.get_ref() as Node
+
+	# travel_dir 传弹道实际方向：斜射时比表面法线取反更准确
+	var info := HitResolver.resolve(
+		ray_result, energy, MedicalEnums.DamageType.BULLET, source, velocity.normalized()
+	)
+	var health_system := player_node.get_node("HealthSystem") as HealthSystem
+	health_system.apply_damage(info)
+
+	GlobalLogger.debug("Ballistics", "Bullet hit at %.1fm: %.0f m/s → %.0f J" % [
+		b["traveled"], impact_speed, energy
+	])
+
+
+## 当前在飞弹丸数量（调试/测试用）
+func get_active_bullet_count() -> int:
+	return _bullets.size()

--- a/Classes/Combat/ballistics.gd
+++ b/Classes/Combat/ballistics.gd
@@ -14,16 +14,41 @@ static func kinetic_energy(mass_kg: float, velocity_mps: float) -> float:
 	return 0.5 * mass_kg * velocity_mps * velocity_mps
 
 
-## 根据射程估算弹头速度衰减（简化指数阻力模型）。[P2 功能，P1 直接使用枪口初速]
-## 模型：v(d) = v₀ × exp(−k × d)，其中 k = 0.0001 / (BC × mass_kg)
+## 单位距离阻力衰减系数 k（1/m）的推导常数：k = DRAG_SCALE / BC。
+## BC（G1 近似）本身已包含质量与截面积信息，因此 k 不再除以质量——
+## 旧公式 k = 0.0001/(BC×mass_kg) 因质量以 kg 计而量纲失衡（k ≈ 0.1/m，
+## 5.45 弹会在 30 米内失速），已修正。
+## 标定：BC 0.22（5.45×39 类）→ k ≈ 0.00114/m → 880 m/s 在 300m 处 ≈ 656 m/s，
+## 与实测弹道表相符。
+const DRAG_SCALE: float = 0.00025
+
+
+## 由弹道系数推导单位距离阻力衰减系数 k（1/m）。
+## [参数] bc 弹道系数（G1 近似，典型值 0.15–0.6）
+## [返回] 单位距离阻力系数 k（1/m）；bc ≤ 0 时返回 0（无阻力）
+static func drag_factor(bc: float) -> float:
+	if bc <= 0.0:
+		return 0.0
+	return DRAG_SCALE / bc
+
+
+## 二次空气阻力减速度（m/s²）：dv/dt = −k·v²。
+## 供 BallisticProjectileSystem 逐帧数值积分使用；与下方闭式解同一模型。
+## [参数] speed_mps 当前速度（m/s）
+## [参数] bc        弹道系数（G1 近似，典型值 0.15–0.6）
+## [返回] 减速度（m/s²，非负）
+static func drag_decel(speed_mps: float, bc: float) -> float:
+	return drag_factor(bc) * speed_mps * speed_mps
+
+
+## 根据射程估算弹头速度衰减（闭式解，供 hitscan 回退路径和调参参考）。
+## 模型：dv/dt = −k·v² 沿弹道积分 → v(d) = v₀ / (1 + k·d)，k = DRAG_SCALE / BC
 ## [参数] muzzle_velocity  枪口初速（m/s）
-## [参数] mass_kg          弹头质量（kg）
-## [参数] bc               弹道系数（G1 标准，典型值 0.2–0.6）
+## [参数] _mass_kg         弹头质量（kg）；保留签名兼容，质量已由 BC 编码，不再参与计算
+## [参数] bc               弹道系数（G1 近似，典型值 0.15–0.6）
 ## [参数] range_m          射程（m）
 ## [返回] 衰减后速度（m/s）；bc ≤ 0 或 range ≤ 0 时直接返回枪口初速
-static func velocity_at_range(muzzle_velocity: float, mass_kg: float, bc: float, range_m: float) -> float:
+static func velocity_at_range(muzzle_velocity: float, _mass_kg: float, bc: float, range_m: float) -> float:
 	if bc <= 0.0 or range_m <= 0.0:
 		return muzzle_velocity
-	# 简化指数衰减：v(d) = v0 × exp(-k × d)，k 由 BC 和质量推导
-	var k: float = 0.0001 / (bc * mass_kg)
-	return muzzle_velocity * exp(-k * range_m)
+	return muzzle_velocity / (1.0 + drag_factor(bc) * range_m)

--- a/Classes/Combat/hit_resolver.gd
+++ b/Classes/Combat/hit_resolver.gd
@@ -50,19 +50,25 @@ static var BONE_PART_MAP: Dictionary = {
 ## [参数] energy_joules  由 Ballistics.kinetic_energy() 预计算的动能（J）
 ## [参数] damage_type    伤害类型（MedicalEnums.DamageType）
 ## [参数] source         攻击来源节点，用于得分/日志
+## [参数] travel_dir     弹头实际飞行方向（归一化，可选）。弹道模拟提供真实方向；
+##                       缺省 ZERO 时回退为表面法线取反（hitscan 老路径，斜射时略有偏差）
 ## [返回] 填充好所有字段的 DamageInfo；无法识别部位时默认 TORSO
 static func resolve(
 	ray_result: Dictionary,
 	energy_joules: float,
 	damage_type: MedicalEnums.DamageType,
-	source: Node
+	source: Node,
+	travel_dir: Vector3 = Vector3.ZERO
 ) -> DamageInfo:
 	var info := DamageInfo.new()
 	info.amount = energy_joules
 	info.type = damage_type
 	info.hit_position = ray_result.get("position", Vector3.ZERO)
-	# normal 指向外（离开碰撞体），取反得弹头入射方向
-	info.direction = ray_result.get("normal", Vector3.ZERO) * -1.0
+	if travel_dir != Vector3.ZERO:
+		info.direction = travel_dir
+	else:
+		# normal 指向外（离开碰撞体），取反近似弹头入射方向
+		info.direction = ray_result.get("normal", Vector3.ZERO) * -1.0
 	info.source = source
 
 	var collider = ray_result.get("collider", null)

--- a/Classes/Combat/projectile.gd
+++ b/Classes/Combat/projectile.gd
@@ -54,7 +54,7 @@ static func fire_hitscan(
 		return
 
 	# 向上寻找 BasePlayer；命中环境（墙/地面）时子弹在此终止
-	var player_node := _find_player(collider)
+	var player_node := find_player(collider)
 	if not player_node:
 		return
 	if not player_node.has_node("HealthSystem"):
@@ -67,8 +67,8 @@ static func fire_hitscan(
 	health_system.apply_damage(info)
 
 
-## 从碰撞体向上查找 BasePlayer 节点
-static func _find_player(node: Object) -> BasePlayer:
+## 从碰撞体向上查找 BasePlayer 节点（供 hitscan 与 BallisticProjectileSystem 共用）
+static func find_player(node: Object) -> BasePlayer:
 	var current := node as Node
 	while current:
 		if current is BasePlayer:

--- a/Classes/Weapon/Weapon/base_weapon.gd
+++ b/Classes/Weapon/Weapon/base_weapon.gd
@@ -355,27 +355,58 @@ func _fire_one_round() -> void:
 	recoil_component.apply_recoil()
 
 
-## 发射弹丸（P1 hitscan 实现）
-## 射线从摄像机沿准星方向发出（枪口起点会产生近距离视差，弹着点偏离准星）；
-## 无摄像机时回退到枪口沿武器朝向。枪口位置留给未来的曳光/开火特效使用。
+## 发射弹丸
+## 弹道模拟开启（WeaponConfig.use_ballistic_simulation）：弹丸从枪口射出，
+##   初始方向指向"摄像机准星射线的命中点"（瞄准收敛），之后受重力/阻力支配。
+## 关闭时回退 P1 hitscan：射线从摄像机沿准星方向瞬时判定（无下坠、满动能）。
 func _spawn_projectile() -> void:
 	var world := get_world_3d()
 	if not world:
 		GlobalLogger.warn("BaseWeapon", "Cannot get World3D, projectile not fired")
 		return
 
+	var exclusions := _collect_shooter_exclusions()
 	var camera := get_viewport().get_camera_3d()
-	var origin: Vector3
-	var shoot_dir: Vector3
-	if camera:
-		origin = camera.global_position
-		shoot_dir = -camera.global_basis.z
-	else:
-		var muzzle_offset: float = config.weapon_length if config else 0.7
-		origin = global_position + global_basis.z * -muzzle_offset
-		shoot_dir = -global_basis.z
 
-	Projectile.fire_hitscan(origin, shoot_dir, config, self, world, _collect_shooter_exclusions())
+	# 摄像机准星射线（无摄像机时回退武器朝向）
+	var aim_origin: Vector3
+	var aim_dir: Vector3
+	if camera:
+		aim_origin = camera.global_position
+		aim_dir = -camera.global_basis.z
+	else:
+		aim_origin = _get_muzzle_position()
+		aim_dir = -global_basis.z
+
+	if config and config.use_ballistic_simulation:
+		# 瞄准收敛：先用准星射线找到玩家实际瞄准的点，
+		# 弹丸再从枪口朝该点飞行，消除枪口/准星视差
+		var aim_point := _resolve_aim_point(aim_origin, aim_dir, world, exclusions)
+		var muzzle := _get_muzzle_position()
+		BallisticProjectileSystem.get_or_create(get_tree()).spawn(
+			muzzle, aim_point - muzzle, config, self, exclusions, world
+		)
+	else:
+		Projectile.fire_hitscan(aim_origin, aim_dir, config, self, world, exclusions)
+
+
+## 枪口世界坐标（武器局部 -Z 方向延伸 weapon_length）
+func _get_muzzle_position() -> Vector3:
+	var muzzle_offset: float = config.weapon_length if config else 0.7
+	return global_position + global_basis.z * -muzzle_offset
+
+
+## 沿准星射线查找瞄准点（环境或目标）；未命中时取 2000m 远点
+func _resolve_aim_point(origin: Vector3, dir: Vector3, world: World3D, exclusions: Array[RID]) -> Vector3:
+	var far_point := origin + dir.normalized() * 2000.0
+	var space_state := world.direct_space_state
+	if not space_state:
+		return far_point
+	var query := PhysicsRayQueryParameters3D.create(origin, far_point, 1 | 2, exclusions)
+	query.collide_with_areas = true
+	query.collide_with_bodies = true
+	var result := space_state.intersect_ray(query)
+	return result.get("position", far_point) if not result.is_empty() else far_point
 
 
 ## 收集射手自身的物理 RID（胶囊体 + 全部 BodyHitbox），

--- a/Classes/Weapon/Weapon/weapon_config.gd
+++ b/Classes/Weapon/Weapon/weapon_config.gd
@@ -133,10 +133,15 @@ extends Resource
 # 以下字段是预留的弹药类型配置，后续需要实现弹种切换功能时启用
 # ============================================================
 # @export var bullet_type: String = "fmj"              # 弹种：fmj（全被甲）/ hp（空尖）/ ap（穿甲）
-# @export var ballistic_coefficient: float = 0.3       # 弹道系数（BC），用于远距离弹道下坠计算
 
 # 弹道学参数 ────────────────────────────────────────────────
 @export_group("弹道学参数 / Ballistics")
 ## 子弹质量（克）；用于弹道动能计算 KE = 0.5 × m × v²
 ## 5.45×39mm 弹头约 3.4–5.2 g；7.62×39mm 约 7.9–8.0 g
 @export var bullet_mass_g: float = 5.2
+## 弹道系数（G1 近似），驱动空气阻力衰减：k = 0.00025 / BC（见 Ballistics）
+## 越大越"滑"，远距离存速越好。5.45×39 ≈ 0.22，7.62×39 ≈ 0.27，7.62×54R ≈ 0.4
+@export_range(0.05, 1.0, 0.01) var ballistic_coefficient: float = 0.25
+## 启用弹道模拟（飞行时间 + 重力下坠 + 空气阻力 + 远距离伤害衰减）。
+## 关闭时回退为瞬时 hitscan（无下坠、满动能命中），便于 A/B 对比调参。
+@export var use_ballistic_simulation: bool = true

--- a/res/config/weapons/ak74m_config.tres
+++ b/res/config/weapons/ak74m_config.tres
@@ -21,4 +21,5 @@ weapon_scene = ExtResource("2_ixgqf")
 weapon_length = 0.943
 muzzle_velocity = 880.0
 bullet_mass_g = 3.45
+ballistic_coefficient = 0.22
 caliber = "5.45x39mm"


### PR DESCRIPTION
Implements the ballistic simulation option from JiYu's directive (medical + bullet scope). Bullets are now simulated in flight:

- New BallisticProjectileSystem (Classes/Combat): shared Node managing all in-flight bullets as data entries (no per-bullet nodes). Each physics frame: quadratic air drag (dv/dt = -k*v^2, k derived from ballistic coefficient), gravity drop, semi-implicit Euler integration, and a segment raycast (layer 1|2, shooter excluded) over the distance swept this frame. Caps: 2000 m range, 8 s flight, 256 active bullets, 40 m/s minimum speed.
- Impact energy uses the speed AT the hit point, so range-dependent
  damage falloff emerges from physics (5.45x39: ~1335 J muzzle ->
  ~740 J at 300 m -> severity 1.11 -> 0.62) with zero new medical code.
- Ballistics: fixed the dimensionally broken velocity_at_range stub (k = 0.0001/(BC*mass_kg) gave k ~ 0.1/m, killing a 5.45 round in 30 m). New model k = 0.00025/BC; added drag_factor()/drag_decel() helpers shared by the closed form and the numeric integrator. Calibrated: BC 0.22 -> 880 m/s falls to ~656 m/s at 300 m, matching published 5.45x39 tables.
- HitResolver.resolve(): optional travel_dir parameter; simulated bullets pass their true flight direction (more accurate than the negated surface normal on oblique hits). Backward compatible.
- Projectile: _find_player renamed to public find_player, shared with the projectile system; hitscan path unchanged and retained.
- WeaponConfig: activates the reserved ballistic_coefficient field (documented per-cartridge values) and adds use_ballistic_simulation toggle (on by default; off = legacy hitscan for A/B tuning).
- BaseWeapon._spawn_projectile(): with simulation on, the bullet leaves the muzzle aimed at the camera-ray convergence point (parallax-free), then flies under gravity/drag; hitscan fallback preserved.
- ak74m_config.tres: ballistic_coefficient = 0.22 (5.45x39).

Medical system API untouched: hits still flow through HitResolver ->
DamageInfo -> HealthSystem.apply_damage().