### PR TITLE
Fix prone transitions, IK, controls, and roll camera

### DIFF
--- a/classes/player/base_player.gd
+++ b/classes/player/base_player.gd
@@ -475,13 +475,12 @@ func _sync_weapon_weight_to_stamina() -> void:
 func _process(delta: float) -> void:
 	var procedural_animation_active := is_alive and not is_ragdolled
 	var prone := stance_controller and (stance_controller.is_prone() or stance_controller.is_prone_transitioning())
-	# Prone authored poses own the upper body, while the left hand still needs
-	# to follow the weapon grip on every frame.
+	# Prone clips are full-body authored animations. Running hand/foot IK on top
+	# of them pulls the limbs toward standing targets and distorts the pose.
 	spine_aim_controller.process_aim(delta, procedural_animation_active and not prone)
 	hand_ik_controller.set_prone_state(prone)
-	hand_ik_controller.process_ik(delta, procedural_animation_active)
-	if procedural_animation_active:
-		foot_ik_controller.process_ik(delta)
+	hand_ik_controller.process_ik(delta, procedural_animation_active and not prone)
+	foot_ik_controller.process_ik(delta, procedural_animation_active and not prone)
 
 
 func _input(event: InputEvent) -> void:

--- a/classes/player/base_player.gd
+++ b/classes/player/base_player.gd
@@ -475,11 +475,11 @@ func _sync_weapon_weight_to_stamina() -> void:
 func _process(delta: float) -> void:
 	var procedural_animation_active := is_alive and not is_ragdolled
 	var prone := stance_controller and (stance_controller.is_prone() or stance_controller.is_prone_transitioning())
-	# Prone clips are full-body authored animations. Running hand/foot IK on top
-	# of them pulls the limbs toward standing targets and distorts the pose.
+	# Prone clips own the spine and lower body, but the left hand must continue
+	# following the weapon grip or the full-body clip lets it release the rifle.
 	spine_aim_controller.process_aim(delta, procedural_animation_active and not prone)
 	hand_ik_controller.set_prone_state(prone)
-	hand_ik_controller.process_ik(delta, procedural_animation_active and not prone)
+	hand_ik_controller.process_ik(delta, procedural_animation_active)
 	foot_ik_controller.process_ik(delta, procedural_animation_active and not prone)
 
 

--- a/classes/player/foot_ik_controller.gd
+++ b/classes/player/foot_ik_controller.gd
@@ -87,10 +87,23 @@ func _setup_ankle_modifier() -> void:
 	_ankle_modifier.setup(_skeleton, self)
 
 
-func process_ik(delta: float) -> void:
+func process_ik(delta: float, active: bool = true) -> void:
 	if not _left_ik and not _right_ik:
 		return
 	if not is_instance_valid(_skeleton):
+		return
+	if not active:
+		# Full-body clips (prone/roll) already author both feet. Clear every
+		# procedural layer immediately so stale standing IK cannot bend them.
+		_left_blend = 0.0
+		_right_blend = 0.0
+		if _left_ik:
+			_left_ik.influence = 0.0
+		if _right_ik:
+			_right_ik.influence = 0.0
+		if _ankle_modifier:
+			_ankle_modifier.left_blend = 0.0
+			_ankle_modifier.right_blend = 0.0
 		return
 
 	var left_hit  := _raycast_foot(_left_foot_idx)

--- a/classes/player/hand_ik_controller.gd
+++ b/classes/player/hand_ik_controller.gd
@@ -162,7 +162,9 @@ func set_prone_state(prone: bool) -> void:
 	if _is_prone == prone:
 		return
 	_is_prone = prone
-	if not prone and is_instance_valid(_elbow_pole):
+	# Prone is animation-owned, so always restore the authored pole instead of
+	# carrying a procedural bend plane into or out of the clip.
+	if is_instance_valid(_elbow_pole):
 		_elbow_pole.transform = _authored_elbow_pole_transform
 	_update_target_weight()
 

--- a/classes/player/hand_ik_controller.gd
+++ b/classes/player/hand_ik_controller.gd
@@ -162,9 +162,9 @@ func set_prone_state(prone: bool) -> void:
 	if _is_prone == prone:
 		return
 	_is_prone = prone
-	# Prone is animation-owned, so always restore the authored pole instead of
-	# carrying a procedural bend plane into or out of the clip.
-	if is_instance_valid(_elbow_pole):
+	# While prone, HandTargetModifier derives the pole from the authored clip's
+	# current bend plane. Restore the standing pole only when leaving prone.
+	if not prone and is_instance_valid(_elbow_pole):
 		_elbow_pole.transform = _authored_elbow_pole_transform
 	_update_target_weight()
 

--- a/classes/player/player_animation_controller.gd
+++ b/classes/player/player_animation_controller.gd
@@ -26,6 +26,9 @@ const SM_CROUCH_TURN_RIGHT := "CrouchTurnRight"
 const SM_PRONE_TURN_LEFT := "ProneTurnLeft"
 const SM_PRONE_TURN_RIGHT := "ProneTurnRight"
 const TURN_THRESHOLD_EPSILON := deg_to_rad(0.1)
+## Direct prone locomotion clips bypass AnimationTree, so they need an
+## explicit blend time when switching between idle and crawl directions.
+const PRONE_LOCOMOTION_BLEND_TIME := 0.16
 
 # AnimationTree 参数路径 ──────────────────────────────────────
 const PARAM_PLAYBACK           := "parameters/playback"
@@ -580,7 +583,8 @@ func play_prone_idle() -> void:
 	var clip: Animation = player.get_animation(anim)
 	clip.loop_mode = Animation.LOOP_LINEAR
 	_prone_animation_override = anim
-	player.play(anim)
+	if player.current_animation != anim:
+		player.play(anim, PRONE_LOCOMOTION_BLEND_TIME)
 
 func play_prone_roll(left: bool) -> float:
 	var player := _prone_player()
@@ -629,7 +633,7 @@ func update_prone_motion(input_dir: Vector2, has_input: bool) -> void:
 	var clip: Animation = player.get_animation(anim)
 	clip.loop_mode = Animation.LOOP_LINEAR
 	if player.current_animation != anim:
-		player.play(anim)
+		player.play(anim, PRONE_LOCOMOTION_BLEND_TIME)
 
 
 func begin_external_turn(turn_state: State, playback_speed: float) -> void:

--- a/classes/player/player_camera_controller.gd
+++ b/classes/player/player_camera_controller.gd
@@ -102,9 +102,8 @@ var _ragdoll_bone_idx: int = -1
 var _ragdoll_head_bone: PhysicalBone3D = null  # 头部物理骨骼
 var _ragdoll_physics_active: bool = false
 var _head_spring_enabled: bool = true
+const PRONE_ROLL_MAX_CAMERA_BANK: float = deg_to_rad(18.0)
 var _prone_roll_camera_angle: float = 0.0
-var _prone_roll_head_to_camera_basis: Basis = Basis.IDENTITY
-var _prone_roll_head_conversion_valid: bool = false
 ## 头部没有对应 PhysicalBone3D 时，使用颈部等最近物理父骨骼，
 ## 该变换把物理骨骼坐标转换为头部坐标，因此仍能保持头部位置/滚转。
 var _ragdoll_head_from_physical: Transform3D = Transform3D.IDENTITY
@@ -219,8 +218,6 @@ func enable_camera() -> void:
 		_active_camera.fov = _camera_config.fov
 
 	_bone_attachment = _find_bone_attachment()
-	_prone_roll_head_to_camera_basis = Basis.IDENTITY
-	_prone_roll_head_conversion_valid = false
 	if _bone_attachment:
 		GlobalLogger.info("Camera", "Head BoneAttachment found: " + _bone_attachment.bone_name)
 	else:
@@ -515,25 +512,16 @@ func _process(delta: float) -> void:
 		_spring_z.update(delta, head_local.z)
 	)
 
-	# 3. 局部空间转全局——玩家旋转正确携带，鼠标转头不触发弹簧
-	# Normal prone uses the same spring camera path as standing. A roll is the
-	# sole authored-pose exception: inherit the head bone's complete rotation.
-	var follow_head := _player and _player.movement_controller and _player.movement_controller.is_prone_rolling()
-	if follow_head and is_instance_valid(_bone_attachment):
-		var head_xform := _bone_attachment.global_transform
-		var offset_xform := head_xform * Transform3D(Basis.IDENTITY, _camera_config.head_offset)
-		_active_camera.global_position = offset_xform.origin
-		_active_camera.global_basis = (
-			head_xform.basis.orthonormalized() * _prone_roll_head_to_camera_basis
-		).orthonormalized()
-	else:
-		_active_camera.global_position = _player.global_transform * filtered_local
-		_active_camera.global_rotation = Vector3(
-			get_vertical_angle() + _pain_pitch,
-			get_view_yaw() + _pain_yaw,
-			_pain_roll + _prone_roll_camera_angle
-		)
-		_cache_prone_roll_head_conversion()
+	# 3. 局部空间转全局——玩家旋转正确携带，鼠标转头不触发弹簧。
+	# The roll animation may rotate the head bone through arbitrary imported
+	# axes. Keep the first-person view driven by look input and add only a small
+	# cosmetic bank, otherwise the camera can reverse or point at the ground.
+	_active_camera.global_position = _player.global_transform * filtered_local
+	_active_camera.global_rotation = Vector3(
+		get_vertical_angle() + _pain_pitch,
+		get_view_yaw() + _pain_yaw,
+		_pain_roll + _prone_roll_camera_angle
+	)
 
 	_update_ads(delta)
 	_update_weapon_spring(delta)
@@ -692,20 +680,13 @@ func set_prone_roll_camera_angle(angle: float) -> void:
 	_prone_roll_camera_angle = angle
 
 
-func _cache_prone_roll_head_conversion() -> void:
-	if not is_instance_valid(_bone_attachment) or not is_instance_valid(_active_camera):
-		return
-	var head_basis := _bone_attachment.global_basis.orthonormalized()
-	_prone_roll_head_to_camera_basis = head_basis.inverse() * _active_camera.global_basis.orthonormalized()
-	_prone_roll_head_conversion_valid = true
-
 func _update_prone_roll_camera(delta: float) -> void:
 	if _player and _player.movement_controller and _player.movement_controller.is_prone_rolling():
 		var progress := _player.movement_controller.get_prone_roll_progress()
 		var direction := _player.movement_controller.get_prone_roll_direction()
-		# Do not use lerp_angle here: 0 and TAU are equivalent and interpolation
-		# would reverse near the half-turn instead of completing the roll.
-		_prone_roll_camera_angle = direction * TAU * progress
+		# A half-sine gives one readable bank and returns to a level horizon at
+		# the end without ever flipping the player's view upside down.
+		_prone_roll_camera_angle = direction * sin(progress * PI) * PRONE_ROLL_MAX_CAMERA_BANK
 		return
 	_prone_roll_camera_angle = wrapf(
 		lerp_angle(

--- a/classes/player/player_movement_controller.gd
+++ b/classes/player/player_movement_controller.gd
@@ -60,6 +60,7 @@ var _prone_roll_timer: float = 0.0
 var _prone_roll_duration: float = 0.0
 var _prone_rolling: bool = false
 var _prone_roll_direction: float = 0.0
+var _prone_roll_world_direction: Vector3 = Vector3.ZERO
 
 
 func is_running() -> bool:
@@ -208,6 +209,7 @@ func _physics_process(delta: float) -> void:
 		var fallback_finished := not has_roll_animation and _prone_roll_timer <= 0.0
 		if animation_finished or fallback_finished:
 			_prone_rolling = false
+			_prone_roll_world_direction = Vector3.ZERO
 			_prone_roll_cooldown = _config.prone_roll_cooldown
 			_prone_roll_timer = 0.0
 			if _camera_controller:
@@ -523,12 +525,17 @@ func _process_prone_movement(delta: float, input_dir: Vector2, has_input: bool, 
 		_velocity.y = _config.floor_snap_velocity
 	var basis: Basis = _camera_controller.get_view_basis() if _camera_controller else _player.global_basis
 	var direction: Vector3 = (basis.x * input_dir.x + basis.z * input_dir.y).normalized() if has_input else Vector3.ZERO
-	var space: bool = not ai_driving and Input.is_action_pressed("jump")
 	var side: bool = abs(input_dir.x) > abs(input_dir.y) and abs(input_dir.x) > _config.input_dead_zone
-	if side and space and not _prone_rolling and _prone_roll_cooldown <= 0.0:
+	if _is_prone_roll_combo_pressed(side, ai_driving) and not _prone_rolling and _prone_roll_cooldown <= 0.0:
 		if not _player.stamina_system or _player.stamina_system.consume_prone_roll():
 			_prone_rolling = true
 			_prone_roll_direction = sign(input_dir.x)
+			var planar_right := basis.x
+			planar_right.y = 0.0
+			if planar_right.length_squared() < 0.000001:
+				planar_right = _player.global_basis.x
+				planar_right.y = 0.0
+			_prone_roll_world_direction = planar_right.normalized() * _prone_roll_direction
 			_prone_roll_duration = _config.prone_roll_duration
 			if _player.animation_controller:
 				var clip_length := _player.animation_controller.play_prone_roll(_prone_roll_direction < 0.0)
@@ -538,8 +545,12 @@ func _process_prone_movement(delta: float, input_dir: Vector2, has_input: bool, 
 			if _camera_controller:
 				_camera_controller.set_prone_roll_camera_angle(0.0)
 	var speed: float = 0.0
+	var movement_direction := direction
+	var should_move := has_input
 	if _prone_rolling:
 		speed = _config.prone_roll_speed
+		movement_direction = _prone_roll_world_direction
+		should_move = not movement_direction.is_zero_approx()
 	elif has_input:
 		if side:
 			speed = _config.prone_lateral_speed
@@ -547,9 +558,9 @@ func _process_prone_movement(delta: float, input_dir: Vector2, has_input: bool, 
 			speed = _config.prone_forward_speed
 		else:
 			speed = _config.prone_backward_speed
-	if has_input:
-		_velocity.x = move_toward(_velocity.x, direction.x * speed, _config.prone_roll_acceleration * delta)
-		_velocity.z = move_toward(_velocity.z, direction.z * speed, _config.prone_roll_acceleration * delta)
+	if should_move:
+		_velocity.x = move_toward(_velocity.x, movement_direction.x * speed, _config.prone_roll_acceleration * delta)
+		_velocity.z = move_toward(_velocity.z, movement_direction.z * speed, _config.prone_roll_acceleration * delta)
 	else:
 		_velocity.x = move_toward(_velocity.x, 0.0, _config.stop_brake_strength * delta)
 		_velocity.z = move_toward(_velocity.z, 0.0, _config.stop_brake_strength * delta)
@@ -560,6 +571,16 @@ func _process_prone_movement(delta: float, input_dir: Vector2, has_input: bool, 
 	# transition complete. Locomotion must not replace them frame-by-frame.
 	if _player.animation_controller and not _prone_rolling and not _player.stance_controller.is_prone_transitioning():
 		_player.animation_controller.update_prone_motion(input_dir, has_input)
+
+
+func _is_prone_roll_combo_pressed(side: bool, ai_driving: bool) -> bool:
+	if ai_driving or not side or not Input.is_action_pressed("jump"):
+		return false
+	# Accept both input orders: hold A/D then press Space, or hold Space then
+	# press A/D. Requiring a fresh edge prevents held keys from chaining rolls.
+	return Input.is_action_just_pressed("jump") \
+		or Input.is_action_just_pressed("move_left") \
+		or Input.is_action_just_pressed("move_right")
 
 
 func _update_collision_shape(stance: float) -> void:

--- a/classes/player/player_movement_controller.gd
+++ b/classes/player/player_movement_controller.gd
@@ -536,7 +536,7 @@ func _process_prone_movement(delta: float, input_dir: Vector2, has_input: bool, 
 					_prone_roll_duration = clip_length
 			_prone_roll_timer = _prone_roll_duration
 			if _camera_controller:
-				_camera_controller.set_prone_roll_camera_angle(0.55 * _prone_roll_direction)
+				_camera_controller.set_prone_roll_camera_angle(0.0)
 	var speed: float = 0.0
 	if _prone_rolling:
 		speed = _config.prone_roll_speed

--- a/classes/player/stance_controller.gd
+++ b/classes/player/stance_controller.gd
@@ -23,7 +23,6 @@ var _prone_transition: bool = false
 var _prone_entering: bool = false
 var _prone_exit_to_stand: bool = false
 var _prone_timer: float = 0.0
-var _stand_after_prone_timer: float = -1.0
 
 var _stance_value: float = 0.0  # 当前姿态（平滑插值后的值）
 var _target_stance: float = 0.0  # 目标姿态（滚轮设定的目标）
@@ -119,7 +118,6 @@ func _enter_prone() -> void:
 	if _prone_transition or _is_prone:
 		return
 	_target_stance = 1.0
-	_stand_after_prone_timer = -1.0
 	_is_prone = true
 	_prone_transition = true
 	_prone_entering = true
@@ -166,10 +164,9 @@ func _finish_prone_exit() -> void:
 	_prone_entering = false
 	var was_prone := _is_prone
 	_is_prone = completing_entry
-	# prone_exit lands in the crouched pose. Hold that pose briefly so the
-	# existing crouch-to-stand Idle blend is visible instead of skipping it.
-	_target_stance = 1.0
-	_stand_after_prone_timer = 0.22 if not completing_entry and _prone_exit_to_stand else -1.0
+	# C exits into crouch. Z exits directly toward standing as soon as the
+	# authored prone-exit clip releases the skeleton.
+	_target_stance = 0.0 if not completing_entry and _prone_exit_to_stand else 1.0
 	_prone_exit_to_stand = false
 	if was_prone != _is_prone:
 		prone_changed.emit(_is_prone)
@@ -180,11 +177,6 @@ func _finish_prone_exit() -> void:
 			_player.animation_controller.clear_prone_override()
 
 func _process(delta: float) -> void:
-	if _stand_after_prone_timer >= 0.0:
-		_stand_after_prone_timer -= delta
-		if _stand_after_prone_timer <= 0.0:
-			_stand_after_prone_timer = -1.0
-			_target_stance = 0.0
 	if _prone_transition:
 		_prone_timer -= delta
 		if _prone_timer <= 0.0:

--- a/tests/prone_controls_check.gd
+++ b/tests/prone_controls_check.gd
@@ -1,0 +1,99 @@
+extends Node
+
+
+func _ready() -> void:
+	_run.call_deferred()
+
+
+func _run() -> void:
+	var scene := load("res://assets/map/TestMap.tscn") as PackedScene
+	if not _check(scene != null, "TestMap scene loads"):
+		return
+
+	var map := scene.instantiate()
+	get_tree().root.add_child(map)
+	await get_tree().process_frame
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+	var player := map.get_node_or_null("CharacterBody3D") as BasePlayer
+	if not _check(player != null, "player initializes"):
+		return
+	var stance := player.stance_controller
+	var movement := player.movement_controller
+	var animation := player.animation_controller
+	var animator := animation._prone_player()
+	if not _check(stance != null and movement != null and animator != null, "prone controllers initialize"):
+		return
+
+	if not _check(PlayerAnimationController.PRONE_LOCOMOTION_BLEND_TIME > 0.0, "prone locomotion uses a non-zero cross-fade"):
+		return
+	animation.play_prone_idle()
+	animator.seek(0.25, true)
+	var idle_position := animator.current_animation_position
+	animation.play_prone_idle()
+	if not _check(animator.current_animation_position >= idle_position, "reselecting prone idle does not restart the clip"):
+		return
+	animation.update_prone_motion(Vector2(0.0, -1.0), true)
+	if not _check(animation._prone_animation_override == &"prone_forward/mixamo_com", "prone movement selects the forward crawl clip"):
+		return
+	animation.update_prone_motion(Vector2.ZERO, false)
+	if not _check(animation._prone_animation_override == &"prone_idle/mixamo_com", "stopping returns to prone idle"):
+		return
+
+	# C must leave prone in a crouch.
+	stance._is_prone = true
+	stance._prone_transition = false
+	var crouch_event := InputEventAction.new()
+	crouch_event.action = &"crouch"
+	crouch_event.pressed = true
+	stance._input(crouch_event)
+	if not _check(stance._prone_transition and not stance._prone_exit_to_stand, "C starts a prone-to-crouch exit"):
+		return
+	stance._finish_prone_exit()
+	if not _check(not stance.is_prone() and is_equal_approx(stance._target_stance, 1.0), "C finishes in crouch"):
+		return
+
+	# Z must leave prone directly toward standing, with no crouch hold timer.
+	stance._is_prone = true
+	stance._prone_transition = false
+	var prone_event := InputEventAction.new()
+	prone_event.action = &"prone"
+	prone_event.pressed = true
+	stance._input(prone_event)
+	if not _check(stance._prone_transition and stance._prone_exit_to_stand, "Z starts a prone-to-stand exit"):
+		return
+	stance._finish_prone_exit()
+	if not _check(not stance.is_prone() and is_zero_approx(stance._target_stance), "Z finishes directly toward standing"):
+		return
+
+	# Either key order in Space+A/D is accepted, and the captured lateral
+	# direction continues driving the character after the keys are released.
+	Input.action_press("move_left")
+	Input.action_press("jump")
+	if not _check(movement._is_prone_roll_combo_pressed(true, false), "Space+A starts a prone roll"):
+		Input.action_release("move_left")
+		Input.action_release("jump")
+		return
+	Input.action_release("move_left")
+	Input.action_release("jump")
+	stance._is_prone = true
+	stance._prone_transition = false
+	movement._prone_rolling = true
+	movement._prone_roll_direction = 1.0
+	movement._prone_roll_world_direction = Vector3.RIGHT
+	movement._velocity = Vector3.ZERO
+	movement._process_prone_movement(0.05, Vector2.ZERO, false, false)
+	if not _check(movement._velocity.x > 0.0, "prone roll keeps its captured direction after A/D is released"):
+		return
+
+	print("prone_controls_check=ok")
+	get_tree().quit(0)
+
+
+func _check(condition: bool, message: String) -> bool:
+	if condition:
+		return true
+	push_error(message)
+	get_tree().quit(1)
+	return false

--- a/tests/prone_controls_check.tscn
+++ b/tests/prone_controls_check.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://tests/prone_controls_check.gd" id="1_test"]
+
+[node name="ProneControlsCheck" type="Node"]
+script = ExtResource("1_test")

--- a/tests/ragdoll_camera_check.gd
+++ b/tests/ragdoll_camera_check.gd
@@ -19,9 +19,9 @@ func _ready() -> void:
 	if not _check(camera != null, "active camera exists"):
 		return
 	var normal_camera_parent := camera.get_parent()
+	controller._vertical_angle = deg_to_rad(-11.0)
+	controller._view_yaw = deg_to_rad(23.0)
 	controller._process(0.016)
-	if not _check(controller._prone_roll_head_conversion_valid, "roll camera caches the normal head-to-camera orientation"):
-		return
 
 	player.stance_controller._is_prone = true
 	var roll_clip_length := player.animation_controller.play_prone_roll(false)
@@ -36,19 +36,23 @@ func _ready() -> void:
 		return
 	player.movement_controller._prone_roll_timer = roll_clip_length * 0.25
 	controller._update_prone_roll_camera(0.016)
-	if not _check(is_equal_approx(controller._prone_roll_camera_angle, TAU * 0.75), "right prone roll camera rotates in the input direction"):
+	var expected_bank := sin(PI * 0.75) * PlayerCameraController.PRONE_ROLL_MAX_CAMERA_BANK
+	if not _check(is_equal_approx(controller._prone_roll_camera_angle, expected_bank), "right prone roll camera uses a bounded bank"):
 		return
 	controller._process(0.016)
-	if controller._bone_attachment:
-		var expected_roll_basis := (
-			controller._bone_attachment.global_basis.orthonormalized()
-			* controller._prone_roll_head_to_camera_basis
-		).orthonormalized()
-		var roll_basis_error := expected_roll_basis.get_rotation_quaternion().angle_to(camera.global_basis.get_rotation_quaternion())
-		if not _check(roll_basis_error < 0.03, "prone roll camera inherits the calibrated head orientation"):
-			return
-		if not _check((-camera.global_basis.z).dot(-expected_roll_basis.z) > 0.99, "prone roll camera does not reverse its forward axis"):
-			return
+	var expected_roll_basis := Basis.from_euler(Vector3(
+		controller.get_vertical_angle() + controller._pain_pitch,
+		controller.get_view_yaw() + controller._pain_yaw,
+		controller._pain_roll + expected_bank
+	)).orthonormalized()
+	var roll_basis_error := expected_roll_basis.get_rotation_quaternion().angle_to(camera.global_basis.get_rotation_quaternion())
+	if not _check(roll_basis_error < 0.03, "prone roll camera remains aligned to look input"):
+		return
+	var level_view_basis := Basis.from_euler(Vector3(
+		controller.get_vertical_angle(), controller.get_view_yaw(), 0.0
+	)).orthonormalized()
+	if not _check((-camera.global_basis.z).dot(-level_view_basis.z) > 0.99, "prone roll camera keeps the player's forward view"):
+		return
 	await get_tree().create_timer(roll_clip_length - player.player_config.prone_roll_duration + 0.2).timeout
 	if not _check(not player.movement_controller.is_prone_rolling(), "roll camera releases only after the animation finishes"):
 		return

--- a/tests/spine_hand_ik_check.gd
+++ b/tests/spine_hand_ik_check.gd
@@ -89,15 +89,26 @@ func _run() -> void:
 		return
 	if not _check(hand_ik._is_prone, "prone state is forwarded to hand IK"):
 		return
+	if not _check(is_equal_approx(hand_ik._target_weight, hand_ik._ik_weight * hand_ik._config.prone_ik_weight), "prone uses its dedicated hand IK weight"):
+		return
 	if not _check(hand_ik._elbow_pole != null, "left-hand IK has an elbow pole"):
+		return
+	if not _check(hand_ik._wrist_to_palm_local.length() > 0.02, "hand IK derives a wrist-to-palm offset from the skeleton"):
 		return
 	var authored_pole := hand_ik._authored_elbow_pole_transform
 	hand_ik._target_modifier._process_modification()
-	if not _check(hand_ik._elbow_pole.transform == authored_pole, "prone keeps the authored elbow bend"):
+	if not _check(hand_ik._elbow_pole.transform != authored_pole, "prone elbow pole follows the animated bend plane"):
 		return
-	if not _check(not hand_ik._target_modifier.sync_enabled, "prone transition disables left-hand IK target syncing"):
+	if not _check(hand_ik._target_modifier.sync_enabled, "prone transition keeps left-hand IK active"):
 		return
-	if not _check(is_zero_approx(hand_ik._ik_node.influence), "prone transition clears hand IK influence"):
+	if not _check(hand_ik._ik_node.influence > 0.0, "prone transition does not clear hand IK influence"):
+		return
+	var transition_grip := hand_ik._get_current_grip_transform()
+	var transition_expected := transition_grip.origin \
+		+ transition_grip.basis.orthonormalized() * hand_ik._config.grip_position_offset \
+		- hand_ik._hand_target.global_basis.orthonormalized() * hand_ik._wrist_to_palm_local \
+			* hand_ik._config.prone_palm_contact_ratio
+	if not _check(hand_ik._hand_target.global_position.distance_to(transition_expected) < 0.002, "hand target continues following the grip during prone transition"):
 		return
 	player.stance_controller._prone_transition = false
 	player.stance_controller._is_prone = false

--- a/tests/spine_hand_ik_check.gd
+++ b/tests/spine_hand_ik_check.gd
@@ -89,26 +89,15 @@ func _run() -> void:
 		return
 	if not _check(hand_ik._is_prone, "prone state is forwarded to hand IK"):
 		return
-	if not _check(is_equal_approx(hand_ik._target_weight, hand_ik._ik_weight * hand_ik._config.prone_ik_weight), "prone uses its dedicated hand IK weight"):
-		return
 	if not _check(hand_ik._elbow_pole != null, "left-hand IK has an elbow pole"):
-		return
-	if not _check(hand_ik._wrist_to_palm_local.length() > 0.02, "hand IK derives a wrist-to-palm offset from the skeleton"):
 		return
 	var authored_pole := hand_ik._authored_elbow_pole_transform
 	hand_ik._target_modifier._process_modification()
-	if not _check(hand_ik._elbow_pole.transform != authored_pole, "prone elbow pole follows the animated bend plane"):
+	if not _check(hand_ik._elbow_pole.transform == authored_pole, "prone keeps the authored elbow bend"):
 		return
-	if not _check(hand_ik._target_modifier.sync_enabled, "prone transition keeps left-hand IK active"):
+	if not _check(not hand_ik._target_modifier.sync_enabled, "prone transition disables left-hand IK target syncing"):
 		return
-	if not _check(hand_ik._ik_node.influence > 0.0, "prone transition does not clear hand IK influence"):
-		return
-	var transition_grip := hand_ik._get_current_grip_transform()
-	var transition_expected := transition_grip.origin \
-		+ transition_grip.basis.orthonormalized() * hand_ik._config.grip_position_offset \
-		- hand_ik._hand_target.global_basis.orthonormalized() * hand_ik._wrist_to_palm_local \
-			* hand_ik._config.prone_palm_contact_ratio
-	if not _check(hand_ik._hand_target.global_position.distance_to(transition_expected) < 0.002, "hand target continues following the grip during prone transition"):
+	if not _check(is_zero_approx(hand_ik._ik_node.influence), "prone transition clears hand IK influence"):
 		return
 	player.stance_controller._prone_transition = false
 	player.stance_controller._is_prone = false


### PR DESCRIPTION
## What changed

- Add a 0.16-second cross-fade between prone idle and directional crawl clips, and avoid restarting prone idle when it is already active.
- Keep left-hand IK active during prone entry, idle, movement, and exit so the hand follows the weapon grip; preserve the animation-derived elbow bend plane.
- Keep spine and foot IK disabled while full-body prone clips own those body regions.
- Make C exit prone into crouch and Z exit directly toward standing without the extra crouch hold.
- Trigger rolls with Space+A/D in either key order, capture the lateral direction at roll start, and keep roll movement going after the keys are released.
- Keep the roll camera aligned with look input and limit it to a bounded 18-degree bank.
- Add focused prone-control regression coverage and full prone hand-IK assertions.

## Root cause

The previous fix disabled every procedural IK solver during prone, including the left-hand solver that must keep the hand attached to the rifle. Prone locomotion also bypasses AnimationTree, so direct AnimationPlayer switches used a zero blend. Z exits intentionally paused in crouch for 0.22 seconds, and roll velocity was recalculated from live A/D input instead of the direction captured at roll start.

## Player impact

Prone idle and movement now transition smoothly, the left hand keeps holding the rifle, C and Z have distinct predictable exit behavior, and Space+A/D rolls complete in the chosen direction without requiring the keys to remain held.

## Checks

- Godot headless editor load passes.
- prone_controls_check.tscn passes.
- spine_hand_ik_check.tscn passes.
- ragdoll_camera_check.tscn passes.
- turn_in_place_check.tscn passes.
