### PR TITLE
Fix prone roll direction and travel

### DIFF
--- a/classes/player/player_camera_controller.gd
+++ b/classes/player/player_camera_controller.gd
@@ -714,7 +714,9 @@ func _update_prone_roll_camera(delta: float) -> void:
 		var direction := _player.movement_controller.get_prone_roll_direction()
 		# A half-sine gives one readable bank and returns to a level horizon at
 		# the end without ever flipping the player's view upside down.
-		_prone_roll_camera_angle = direction * sin(progress * PI) * PRONE_ROLL_MAX_CAMERA_BANK
+		# Camera3D looks along -Z, so its screen-space bank uses the opposite
+		# sign from the player's lateral input (right roll = negative Z bank).
+		_prone_roll_camera_angle = -direction * sin(progress * PI) * PRONE_ROLL_MAX_CAMERA_BANK
 		return
 	_prone_roll_camera_angle = wrapf(
 		lerp_angle(

--- a/classes/player/player_movement_controller.gd
+++ b/classes/player/player_movement_controller.gd
@@ -58,6 +58,10 @@ var _ai_input_sprinting: bool = false
 var _prone_roll_cooldown: float = 0.0
 var _prone_roll_timer: float = 0.0
 var _prone_roll_duration: float = 0.0
+## The authored clips are 2.5-3.27s long, but only the configured opening
+## window should propel the CharacterBody. Camera/animation timing stays on
+## _prone_roll_timer so visual playback cannot turn into a multi-metre slide.
+var _prone_roll_motion_timer: float = 0.0
 var _prone_rolling: bool = false
 var _prone_roll_direction: float = 0.0
 var _prone_roll_world_direction: Vector3 = Vector3.ZERO
@@ -204,6 +208,7 @@ func _physics_process(delta: float) -> void:
 		_prone_roll_cooldown -= delta
 	if _prone_rolling:
 		_prone_roll_timer -= delta
+		_prone_roll_motion_timer = maxf(_prone_roll_motion_timer - delta, 0.0)
 		var has_roll_animation := _player.animation_controller != null
 		var animation_finished := has_roll_animation and not _player.animation_controller.is_prone_roll_playing()
 		var fallback_finished := not has_roll_animation and _prone_roll_timer <= 0.0
@@ -212,6 +217,7 @@ func _physics_process(delta: float) -> void:
 			_prone_roll_world_direction = Vector3.ZERO
 			_prone_roll_cooldown = _config.prone_roll_cooldown
 			_prone_roll_timer = 0.0
+			_prone_roll_motion_timer = 0.0
 			if _camera_controller:
 				_camera_controller.set_prone_roll_camera_angle(0.0)
 			if _player.animation_controller and _player.stance_controller and _player.stance_controller.is_prone():
@@ -541,15 +547,20 @@ func _process_prone_movement(delta: float, input_dir: Vector2, has_input: bool, 
 				if clip_length > 0.0:
 					_prone_roll_duration = clip_length
 			_prone_roll_timer = _prone_roll_duration
+			_prone_roll_motion_timer = minf(_config.prone_roll_duration, _prone_roll_duration)
 			if _camera_controller:
 				_camera_controller.set_prone_roll_camera_angle(0.0)
 	var speed: float = 0.0
 	var movement_direction := direction
 	var should_move := has_input
 	if _prone_rolling:
-		speed = _config.prone_roll_speed
-		movement_direction = _prone_roll_world_direction
-		should_move = not movement_direction.is_zero_approx()
+		if _prone_roll_motion_timer > 0.0:
+			speed = _config.prone_roll_speed
+			movement_direction = _prone_roll_world_direction
+			should_move = not movement_direction.is_zero_approx()
+		else:
+			movement_direction = Vector3.ZERO
+			should_move = false
 	elif has_input:
 		if side:
 			speed = _config.prone_lateral_speed
@@ -561,8 +572,9 @@ func _process_prone_movement(delta: float, input_dir: Vector2, has_input: bool, 
 		_velocity.x = move_toward(_velocity.x, movement_direction.x * speed, _config.prone_roll_acceleration * delta)
 		_velocity.z = move_toward(_velocity.z, movement_direction.z * speed, _config.prone_roll_acceleration * delta)
 	else:
-		_velocity.x = move_toward(_velocity.x, 0.0, _config.stop_brake_strength * delta)
-		_velocity.z = move_toward(_velocity.z, 0.0, _config.stop_brake_strength * delta)
+		var brake_strength := _config.prone_roll_acceleration if _prone_rolling else _config.stop_brake_strength
+		_velocity.x = move_toward(_velocity.x, 0.0, brake_strength * delta)
+		_velocity.z = move_toward(_velocity.z, 0.0, brake_strength * delta)
 	_player.velocity = _velocity
 	_player.move_and_slide()
 	_velocity = _player.velocity

--- a/tests/prone_controls_check.gd
+++ b/tests/prone_controls_check.gd
@@ -82,9 +82,25 @@ func _run() -> void:
 	movement._prone_rolling = true
 	movement._prone_roll_direction = 1.0
 	movement._prone_roll_world_direction = Vector3.RIGHT
+	movement._prone_roll_duration = 3.0
+	movement._prone_roll_timer = 3.0
+	movement._prone_roll_motion_timer = player.player_config.prone_roll_duration
 	movement._velocity = Vector3.ZERO
 	movement._process_prone_movement(0.05, Vector2.ZERO, false, false)
 	if not _check(movement._velocity.x > 0.0, "prone roll keeps its captured direction after A/D is released"):
+		return
+
+	# A long authored clip may keep the animation/camera active, but it must not
+	# keep propelling the CharacterBody after the configured roll window.
+	movement._prone_roll_motion_timer = 0.0
+	movement._velocity = Vector3.RIGHT * player.player_config.prone_roll_speed
+	movement._process_prone_movement(0.05, Vector2.ZERO, false, false)
+	if not _check(
+		movement.is_prone_rolling() and movement._prone_roll_timer > player.player_config.prone_roll_duration,
+		"roll animation remains active after propulsion ends"
+	):
+		return
+	if not _check(movement._velocity.x < player.player_config.prone_roll_speed, "expired roll propulsion brakes instead of sliding through the full clip"):
 		return
 
 	print("prone_controls_check=ok")

--- a/tests/ragdoll_camera_check.gd
+++ b/tests/ragdoll_camera_check.gd
@@ -31,14 +31,22 @@ func _ready() -> void:
 	player.movement_controller._prone_roll_direction = 1.0
 	player.movement_controller._prone_roll_duration = roll_clip_length
 	player.movement_controller._prone_roll_timer = roll_clip_length
+	player.movement_controller._prone_roll_motion_timer = player.player_config.prone_roll_duration
 	await get_tree().create_timer(player.player_config.prone_roll_duration + 0.1).timeout
 	if not _check(player.movement_controller.is_prone_rolling(), "camera remains in roll mode after the legacy timer expires"):
 		return
 	player.movement_controller._prone_roll_timer = roll_clip_length * 0.25
 	controller._update_prone_roll_camera(0.016)
-	var expected_bank := sin(PI * 0.75) * PlayerCameraController.PRONE_ROLL_MAX_CAMERA_BANK
-	if not _check(is_equal_approx(controller._prone_roll_camera_angle, expected_bank), "right prone roll camera uses a bounded bank"):
+	var bank_magnitude := sin(PI * 0.75) * PlayerCameraController.PRONE_ROLL_MAX_CAMERA_BANK
+	var expected_bank := -bank_magnitude
+	if not _check(is_equal_approx(controller._prone_roll_camera_angle, expected_bank), "right prone roll camera banks toward the right"):
 		return
+	player.movement_controller._prone_roll_direction = -1.0
+	controller._update_prone_roll_camera(0.016)
+	if not _check(is_equal_approx(controller._prone_roll_camera_angle, bank_magnitude), "left prone roll camera banks toward the left"):
+		return
+	player.movement_controller._prone_roll_direction = 1.0
+	controller._update_prone_roll_camera(0.016)
 	controller._process(0.016)
 	var expected_roll_basis := Basis.from_euler(Vector3(
 		controller.get_vertical_angle() + controller._pain_pitch,


### PR DESCRIPTION
## What changed

- Reverse the prone-roll camera bank sign so left and right rolls visually follow their input direction.
- Separate the authored animation/camera duration from CharacterBody propulsion.
- Limit roll propulsion to the configured 0.45-second window, then brake with roll acceleration while the animation completes.
- Add regression coverage for both camera directions and for ending propulsion during a longer animation clip.

## Why

`Camera3D` looks along `-Z`, so applying the lateral input sign directly produced the opposite screen-space bank. Separately, the movement controller replaced the configured 0.45-second movement duration with the 2.5-3.27-second authored clip length, propelling the player through the entire animation and creating an excessive slide.

## Impact

Prone rolls now bank in the expected direction and travel a bounded distance without truncating the authored animation or camera effect.

## Validation

- `prone_controls_check` passed
- `ragdoll_camera_check` passed
- `turn_in_place_check` passed
- Headless main-scene smoke test passed
- `git diff --check`
