### PR TITLE
Fix collision fitting and refresh title menu

### DIFF
--- a/assets/title/title_ui.tscn
+++ b/assets/title/title_ui.tscn
@@ -5,20 +5,64 @@
 [ext_resource type="AudioStream" uid="uid://cvjppo3omawtu" path="res://assets/audio/menu.wav" id="3_menu_music"]
 
 [sub_resource type="StyleBoxFlat" id="ButtonNormal"]
-content_margin_left = 18.0
-content_margin_top = 10.0
+content_margin_left = 20.0
+content_margin_top = 11.0
 content_margin_right = 18.0
-content_margin_bottom = 10.0
-bg_color = Color(0, 0, 0, 0)
-border_color = Color(0, 0, 0, 0)
+content_margin_bottom = 11.0
+bg_color = Color(0.008, 0.012, 0.018, 0.42)
+border_width_left = 2
+border_color = Color(0.85, 0.72, 0.2, 0.28)
+corner_radius_top_right = 2
+corner_radius_bottom_right = 2
 
 [sub_resource type="StyleBoxFlat" id="ButtonHover"]
-content_margin_left = 18.0
-content_margin_top = 10.0
+content_margin_left = 24.0
+content_margin_top = 11.0
 content_margin_right = 18.0
+content_margin_bottom = 11.0
+bg_color = Color(0.85, 0.72, 0.2, 0.13)
+border_width_left = 4
+border_color = Color(0.95, 0.78, 0.2, 1)
+corner_radius_top_right = 2
+corner_radius_bottom_right = 2
+
+[sub_resource type="StyleBoxFlat" id="ButtonPressed"]
+content_margin_left = 24.0
+content_margin_top = 11.0
+content_margin_right = 18.0
+content_margin_bottom = 11.0
+bg_color = Color(0.85, 0.72, 0.2, 0.22)
+border_width_left = 4
+border_color = Color(0.95, 0.78, 0.2, 1)
+corner_radius_top_right = 2
+corner_radius_bottom_right = 2
+
+[sub_resource type="StyleBoxFlat" id="ButtonDisabled"]
+content_margin_left = 20.0
+content_margin_top = 11.0
+content_margin_right = 18.0
+content_margin_bottom = 11.0
+bg_color = Color(0.008, 0.012, 0.018, 0.24)
+border_width_left = 2
+border_color = Color(0.35, 0.37, 0.4, 0.25)
+corner_radius_top_right = 2
+corner_radius_bottom_right = 2
+
+[sub_resource type="StyleBoxFlat" id="MenuPanel"]
+bg_color = Color(0.008, 0.012, 0.02, 0.88)
+border_width_right = 1
+border_color = Color(0.85, 0.72, 0.2, 0.25)
+
+[sub_resource type="StyleBoxFlat" id="StatusPanel"]
+content_margin_left = 14.0
+content_margin_top = 10.0
+content_margin_right = 14.0
 content_margin_bottom = 10.0
-bg_color = Color(0, 0, 0, 0)
-border_color = Color(0, 0, 0, 0)
+bg_color = Color(0.12, 0.025, 0.015, 0.55)
+border_width_left = 2
+border_color = Color(0.72, 0.2, 0.1, 0.8)
+corner_radius_top_right = 2
+corner_radius_bottom_right = 2
 
 [sub_resource type="Animation" id="AnimationReset"]
 resource_name = "RESET"
@@ -85,117 +129,205 @@ layer = 10
 
 [node name="MenuRoot" type="Control" parent="." unique_id=1162510687]
 layout_mode = 3
-anchors_preset = 0
-offset_left = 106.0
-offset_top = 106.0
-offset_right = 364.0
-offset_bottom = 544.0
-
-[node name="Content" type="VBoxContainer" parent="MenuRoot" unique_id=1162510688]
-layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = -11.0
-offset_top = 108.0
-offset_right = 177.0
-offset_bottom = 181.0
 grow_horizontal = 2
 grow_vertical = 2
-theme_override_constants/separation = 12
+
+[node name="MenuPanel" type="Panel" parent="MenuRoot"]
+layout_mode = 1
+anchors_preset = 12
+anchor_right = 0.42
+anchor_bottom = 1.0
+offset_right = 24.0
+grow_vertical = 2
+mouse_filter = 2
+theme_override_styles/panel = SubResource("MenuPanel")
+
+[node name="TopRule" type="ColorRect" parent="MenuRoot"]
+layout_mode = 1
+anchors_preset = 10
+anchor_right = 0.42
+offset_right = 24.0
+offset_bottom = 3.0
+grow_horizontal = 2
+mouse_filter = 2
+color = Color(0.85, 0.72, 0.2, 0.82)
+
+[node name="Content" type="VBoxContainer" parent="MenuRoot" unique_id=1162510688]
+layout_mode = 1
+anchors_preset = 4
+anchor_top = 0.5
+anchor_bottom = 0.5
+offset_left = 72.0
+offset_top = -356.0
+offset_right = 620.0
+offset_bottom = 356.0
+grow_vertical = 2
+theme_override_constants/separation = 8
+
+[node name="Kicker" type="Label" parent="MenuRoot/Content"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.85, 0.72, 0.2, 0.92)
+theme_override_fonts/font = ExtResource("1_ubark")
+theme_override_font_sizes/font_size = 14
+text = "NORTHLINE COMMAND  /  FIELD OPERATIONS"
 
 [node name="Title" type="Label" parent="MenuRoot/Content" unique_id=1093600405]
 layout_mode = 2
 theme_override_fonts/font = ExtResource("1_ubark")
-theme_override_font_sizes/font_size = 100
+theme_override_font_sizes/font_size = 92
 text = "CONFLICT"
 
 [node name="Subtitle" type="Label" parent="MenuRoot/Content" unique_id=276462994]
 layout_mode = 2
 theme_override_colors/font_color = Color(0.85, 0.72, 0.2, 1)
-theme_override_font_sizes/font_size = 11
+theme_override_fonts/font = ExtResource("1_ubark")
+theme_override_font_sizes/font_size = 14
 text = "THE LINE BETWEEN ORDER AND CHAOS"
 
-[node name="ContinueButton" type="Button" parent="MenuRoot/Content" unique_id=508061250]
-custom_minimum_size = Vector2(0, 42)
+[node name="TitleRule" type="ColorRect" parent="MenuRoot/Content"]
+custom_minimum_size = Vector2(132, 2)
 layout_mode = 2
-theme_override_font_sizes/font_size = 30
+mouse_filter = 2
+color = Color(0.85, 0.72, 0.2, 0.9)
+
+[node name="MenuSpacer" type="Control" parent="MenuRoot/Content"]
+custom_minimum_size = Vector2(0, 12)
+layout_mode = 2
+mouse_filter = 2
+
+[node name="ContinueButton" type="Button" parent="MenuRoot/Content" unique_id=508061250]
+custom_minimum_size = Vector2(0, 50)
+layout_mode = 2
+theme_override_colors/font_disabled_color = Color(0.45, 0.47, 0.5, 0.68)
+theme_override_fonts/font = ExtResource("1_ubark")
+theme_override_font_sizes/font_size = 23
 theme_override_styles/normal = SubResource("ButtonNormal")
 theme_override_styles/hover = SubResource("ButtonHover")
 theme_override_styles/focus = SubResource("ButtonHover")
+theme_override_styles/disabled = SubResource("ButtonDisabled")
 disabled = true
-text = "继续游戏  ·  无存档"
+text = "继续游戏    /    暂无存档"
 flat = true
+alignment = 0
 
 [node name="StartButton" type="Button" parent="MenuRoot/Content" unique_id=535178525]
-custom_minimum_size = Vector2(0, 42)
+custom_minimum_size = Vector2(0, 50)
 layout_mode = 2
 theme_override_colors/font_focus_color = Color(0.95, 0.78, 0.2, 1)
 theme_override_colors/font_hover_color = Color(0.95, 0.78, 0.2, 1)
-theme_override_font_sizes/font_size = 30
+theme_override_fonts/font = ExtResource("1_ubark")
+theme_override_font_sizes/font_size = 26
 theme_override_styles/normal = SubResource("ButtonNormal")
 theme_override_styles/hover = SubResource("ButtonHover")
 theme_override_styles/focus = SubResource("ButtonHover")
+theme_override_styles/pressed = SubResource("ButtonPressed")
 text = "开始游戏"
 flat = true
+alignment = 0
 
 [node name="SettingsButton" type="Button" parent="MenuRoot/Content" unique_id=933548167]
-custom_minimum_size = Vector2(0, 42)
+custom_minimum_size = Vector2(0, 50)
 layout_mode = 2
 theme_override_colors/font_focus_color = Color(0.95, 0.78, 0.2, 1)
 theme_override_colors/font_hover_color = Color(0.95, 0.78, 0.2, 1)
-theme_override_font_sizes/font_size = 30
+theme_override_fonts/font = ExtResource("1_ubark")
+theme_override_font_sizes/font_size = 26
 theme_override_styles/normal = SubResource("ButtonNormal")
 theme_override_styles/hover = SubResource("ButtonHover")
 theme_override_styles/focus = SubResource("ButtonHover")
+theme_override_styles/pressed = SubResource("ButtonPressed")
 text = "设置"
 flat = true
+alignment = 0
 
 [node name="CreditsButton" type="Button" parent="MenuRoot/Content" unique_id=710310197]
-custom_minimum_size = Vector2(0, 42)
+custom_minimum_size = Vector2(0, 50)
 layout_mode = 2
 theme_override_colors/font_focus_color = Color(0.95, 0.78, 0.2, 1)
 theme_override_colors/font_hover_color = Color(0.95, 0.78, 0.2, 1)
-theme_override_font_sizes/font_size = 30
+theme_override_fonts/font = ExtResource("1_ubark")
+theme_override_font_sizes/font_size = 26
 theme_override_styles/normal = SubResource("ButtonNormal")
 theme_override_styles/hover = SubResource("ButtonHover")
 theme_override_styles/focus = SubResource("ButtonHover")
+theme_override_styles/pressed = SubResource("ButtonPressed")
 text = "制作人员"
 flat = true
+alignment = 0
 
 [node name="QuitButton" type="Button" parent="MenuRoot/Content" unique_id=994652732]
-custom_minimum_size = Vector2(0, 42)
+custom_minimum_size = Vector2(0, 50)
 layout_mode = 2
 theme_override_colors/font_focus_color = Color(0.95, 0.78, 0.2, 1)
 theme_override_colors/font_hover_color = Color(0.95, 0.78, 0.2, 1)
-theme_override_font_sizes/font_size = 30
+theme_override_fonts/font = ExtResource("1_ubark")
+theme_override_font_sizes/font_size = 26
 theme_override_styles/normal = SubResource("ButtonNormal")
 theme_override_styles/hover = SubResource("ButtonHover")
 theme_override_styles/focus = SubResource("ButtonHover")
+theme_override_styles/pressed = SubResource("ButtonPressed")
 text = "退出"
 flat = true
+alignment = 0
+
+[node name="StatusSpacer" type="Control" parent="MenuRoot/Content"]
+custom_minimum_size = Vector2(0, 6)
+layout_mode = 2
+mouse_filter = 2
 
 [node name="Status" type="Label" parent="MenuRoot/Content" unique_id=582764000]
 layout_mode = 2
-theme_override_colors/font_color = Color(0.9403621, 3.4172833e-06, 3.85046e-07, 1)
-theme_override_font_sizes/font_size = 20
-text = "⚠️注意！
-这是 Conflict 的测试版本
-测试版本不代表最终品质
-"
+theme_override_colors/font_color = Color(0.94, 0.55, 0.42, 1)
+theme_override_fonts/font = ExtResource("1_ubark")
+theme_override_font_sizes/font_size = 15
+theme_override_styles/normal = SubResource("StatusPanel")
+text = "PRE-ALPHA 测试版本
+当前内容与表现不代表最终品质"
 
 [node name="Version" type="Label" parent="." unique_id=850998614]
-offset_left = 72.0
-offset_top = 1318.0
-offset_right = 350.0
-offset_bottom = 1342.0
+layout_mode = 1
+anchors_preset = 3
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -298.0
+offset_top = -48.0
+offset_right = -48.0
+offset_bottom = -24.0
+grow_horizontal = 0
+grow_vertical = 0
 theme_override_colors/font_color = Color(0.55, 0.58, 0.63, 0.8)
-theme_override_font_sizes/font_size = 11
+theme_override_fonts/font = ExtResource("1_ubark")
+theme_override_font_sizes/font_size = 13
 text = "PRE-ALPHA  ·  BUILD 01"
+horizontal_alignment = 2
+
+[node name="InputHint" type="Label" parent="."]
+layout_mode = 1
+anchors_preset = 2
+anchor_top = 1.0
+anchor_bottom = 1.0
+offset_left = 72.0
+offset_top = -48.0
+offset_right = 402.0
+offset_bottom = -24.0
+grow_vertical = 0
+theme_override_colors/font_color = Color(0.55, 0.58, 0.63, 0.8)
+theme_override_fonts/font = ExtResource("1_ubark")
+theme_override_font_sizes/font_size = 13
+text = "ENTER  选择    ·    鼠标  导航"
 
 [node name="Fade" type="ColorRect" parent="." unique_id=944075701]
-offset_right = 1152.0
-offset_bottom = 648.0
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 mouse_filter = 2
 color = Color(0, 0, 0, 0)
 

--- a/classes/combat/body_hitbox.gd
+++ b/classes/combat/body_hitbox.gd
@@ -73,6 +73,17 @@ func get_bounds_in_space(relative_inverse: Transform3D) -> AABB:
 	return AABB(relative_transform.origin - transformed_half, transformed_half * 2.0)
 
 
+## Returns the hitbox anchor in another local space without exposing the node.
+## HealthSystem uses these bone-following anchors to describe the body's core
+## pose for environment collision. The full medical volume remains available
+## through get_bounds_in_space() for hit detection and debug rendering.
+func get_center_in_space(relative_inverse: Transform3D) -> Vector3:
+	var collision := _collision_shape
+	if not collision or collision.disabled or not collision.shape:
+		return Vector3.INF
+	return (relative_inverse * collision.global_transform).origin
+
+
 func _shape_half_extents(shape: Shape3D) -> Vector3:
 	if shape is SphereShape3D:
 		var radius := (shape as SphereShape3D).radius

--- a/classes/player/base_player.gd
+++ b/classes/player/base_player.gd
@@ -315,6 +315,7 @@ func _connect_signals() -> void:
 	# 连接姿态变化信号
 	stance_controller.stance_changed.connect(_on_stance_changed)
 	stance_controller.prone_geometry_changed.connect(_on_prone_geometry_changed)
+	collision_controller.transition_blocked.connect(_on_collision_transition_blocked)
 	# Sprint 开始时强制取消 ADS，并同步 IK 状态
 	movement_controller.started_sprinting.connect(_on_started_sprinting)
 	# 运动状态 → 左手 IK 权重过渡
@@ -671,6 +672,13 @@ func _on_stance_changed(value: float) -> void:
 
 func _on_prone_geometry_changed(_blend: float) -> void:
 	_sync_pose_geometry()
+
+
+## Collision owns world-clearance policy; stance owns pose state. BasePlayer is
+## the only place that translates the value-only rejection signal between them.
+func _on_collision_transition_blocked() -> void:
+	if stance_controller:
+		stance_controller.reject_collision_transition()
 
 
 ## BasePlayer is the composition root for pose presentation. Components receive

--- a/classes/player/medical/health_system.gd
+++ b/classes/player/medical/health_system.gd
@@ -244,25 +244,29 @@ func get_hitbox_rids() -> Array[RID]:
 	return rids
 
 
-## Returns a value-only snapshot containing all current bone-following hitboxes
-## in player-local space. HealthSystem remains the sole owner of hitbox nodes;
-## presentation and movement components cannot retain or mutate them.
+## Returns a value-only snapshot of the current bone-following hitbox anchors
+## in player-local space. This is deliberately the body's core pose envelope,
+## not the union of every medical shape AABB: fitting the rectangular corners
+## of hands, feet, and rotated hit volumes into one capsule greatly overstates
+## the space occupied by the character. HealthSystem remains the sole owner of
+## hitbox nodes; movement receives only this immutable AABB value.
 func get_collision_envelope() -> AABB:
 	if not _player:
 		return AABB()
-	var envelope := AABB()
-	var has_bounds := false
+	var minimum := Vector3.INF
+	var maximum := -Vector3.INF
+	var has_center := false
 	var player_inverse := _player.global_transform.affine_inverse()
 	for hitbox in _hitboxes:
 		if not is_instance_valid(hitbox):
 			continue
-		var hitbox_bounds := hitbox.get_bounds_in_space(player_inverse)
-		if hitbox_bounds.size.x <= 0.0 or hitbox_bounds.size.y <= 0.0 \
-			or hitbox_bounds.size.z <= 0.0:
+		var center := hitbox.get_center_in_space(player_inverse)
+		if not center.is_finite():
 			continue
-		envelope = envelope.merge(hitbox_bounds) if has_bounds else hitbox_bounds
-		has_bounds = true
-	return envelope if has_bounds else AABB()
+		minimum = minimum.min(center)
+		maximum = maximum.max(center)
+		has_center = true
+	return AABB(minimum, maximum - minimum) if has_center else AABB()
 
 
 ## Resolves a presentation-safe snapshot of the most important external bleed.

--- a/classes/player/movement_config.gd
+++ b/classes/player/movement_config.gd
@@ -127,9 +127,9 @@ extends Resource
 @export var collision_shape_radius: float = 0.4
 ## 碰撞体 Y 轴偏移（m）
 @export var collision_shape_y_offset: float = 0.0
-## 根据当前 BodyHitbox 的完整 3D 包络自动拟合主碰撞胶囊。
+## 根据当前 BodyHitbox 骨架中心形成的 3D 核心包络自动拟合主碰撞胶囊。
 @export var hitbox_driven_collision: bool = true
-## 命中箱 3D 包络之外保留的统一安全余量（m）。
+## 核心包络之外保留的统一安全余量（m）。
 @export_range(0.0, 0.2, 0.005) var collision_bounds_margin: float = 0.025
 ## 主碰撞胶囊尺寸和中心追随包络的最大速度（m/s）。
 @export_range(0.1, 10.0, 0.1) var collision_bounds_follow_speed: float = 2.0

--- a/classes/player/player_collision_controller.gd
+++ b/classes/player/player_collision_controller.gd
@@ -20,6 +20,15 @@ signal geometry_changed(
 	center: Vector3,
 	floor_y: float
 )
+## Emitted once when an expanding/rotating candidate cannot occupy the world.
+## BasePlayer may translate this value-only event into a stance rollback.
+signal transition_blocked
+
+const ENVELOPE_SAMPLE_INTERVAL := 1.0 / 30.0
+const ENVELOPE_EPSILON := 0.002
+const GEOMETRY_EPSILON := 0.0005
+const CLEARANCE_SKIN := 0.003
+const FIT_SEARCH_STEPS := 96
 
 var _body: CharacterBody3D
 var _config: MovementConfig
@@ -34,6 +43,13 @@ var _fit_axis := Vector3.UP
 var _fit_center := Vector3.ZERO
 var _fit_height: float = 1.8
 var _fit_radius: float = 0.4
+var _sample_elapsed: float = INF
+var _last_sampled_envelope := AABB()
+var _has_sampled_envelope: bool = false
+var _fallback_dirty: bool = true
+var _transition_blocked_emitted: bool = false
+var _geometry_write_count: int = 0
+var _envelope_sample_count: int = 0
 
 
 func initialize(
@@ -53,12 +69,18 @@ func initialize(
 ## return AABB and should not expose nodes or mutable component state.
 func set_envelope_provider(provider: Callable) -> void:
 	_envelope_provider = provider
+	_has_sampled_envelope = false
+	_sample_elapsed = INF
 
 
 ## Supplies a value-only fallback for startup/model reload. Live hitbox data
 ## takes priority whenever the injected provider returns a valid envelope.
 func set_fallback_height(height: float) -> void:
-	_fallback_height = maxf(height, 0.01)
+	var next_height := maxf(height, 0.01)
+	if is_equal_approx(_fallback_height, next_height):
+		return
+	_fallback_height = next_height
+	_fallback_dirty = true
 
 
 ## Returns the only environment collision shape owned by this component.
@@ -91,16 +113,49 @@ func get_vertical_extent() -> float:
 	return _vertical_half_extent(capsule.height, capsule.radius, get_capsule_axis()) * 2.0
 
 
+func get_geometry_write_count() -> int:
+	return _geometry_write_count
+
+
+func get_envelope_sample_count() -> int:
+	return _envelope_sample_count
+
+
+## Test/debug inspection API. Normal gameplay consumes geometry_changed instead.
+func contains_envelope(envelope: AABB, tolerance: float = 0.002) -> bool:
+	if not _collision_shape or not (_collision_shape.shape is CapsuleShape3D):
+		return false
+	var capsule := _collision_shape.shape as CapsuleShape3D
+	var axis := get_capsule_axis()
+	for corner in _aabb_corners(envelope):
+		if not _capsule_contains_point(
+			corner,
+			_collision_shape.position,
+			axis,
+			capsule.height,
+			capsule.radius,
+			tolerance
+		):
+			return false
+	return true
+
+
 ## Deterministic setup/test hook. Normal gameplay follows the same target from
 ## _physics_process with speed limits and axis-switch stability.
 func refresh_immediately() -> void:
 	_update_geometry(0.0, true)
+	_sample_elapsed = 0.0
 
 
 func _physics_process(delta: float) -> void:
-	if not _body:
+	if not _body or not _collision_shape or _collision_shape.disabled:
 		return
-	_update_geometry(delta, false)
+	_sample_elapsed += delta
+	var should_sample := _sample_elapsed >= ENVELOPE_SAMPLE_INTERVAL \
+		or not _has_sampled_envelope or _fallback_dirty
+	_update_geometry(delta, false, should_sample)
+	if should_sample:
+		_sample_elapsed = 0.0
 
 
 func _ensure_collision_shape() -> void:
@@ -120,14 +175,26 @@ func _ensure_collision_shape() -> void:
 	_collision_shape.quaternion = Quaternion.IDENTITY
 
 
-func _update_geometry(delta: float, snap: bool) -> void:
+func _update_geometry(delta: float, snap: bool, sample: bool = true) -> void:
 	if not _collision_shape or not (_collision_shape.shape is CapsuleShape3D):
 		return
-	var envelope := _sample_envelope()
-	if _envelope_is_valid(envelope):
-		_fit_envelope(envelope, snap)
-	else:
-		_fit_fallback(snap)
+	if sample:
+		var envelope := _sample_envelope()
+		_envelope_sample_count += 1
+		var envelope_changed := not _has_sampled_envelope \
+			or not _aabb_is_equal_approx(envelope, _last_sampled_envelope)
+		# Axis hysteresis needs repeated samples even when the numeric envelope is
+		# stable, but an already-selected pose does not need to be refitted.
+		var axis_pending := _pending_axis_frames > 0
+		if _envelope_is_valid(envelope):
+			if envelope_changed or axis_pending or _fallback_dirty:
+				_fit_envelope(envelope, snap)
+		else:
+			if envelope_changed or _fallback_dirty:
+				_fit_fallback(snap)
+		_last_sampled_envelope = envelope
+		_has_sampled_envelope = true
+		_fallback_dirty = false
 	_apply_target(delta, snap)
 
 
@@ -145,39 +212,149 @@ func _fit_envelope(envelope: AABB, snap_axis: bool) -> void:
 		envelope.size + Vector3.ONE * margin * 2.0
 	)
 	var axis := _select_axis(padded.size, snap_axis)
-	var center := padded.get_center()
-	var radius: float
-	var height: float
-	if absf(axis.y) > 0.5:
-		radius = maxf(padded.size.x, padded.size.z) * 0.5
-		# A standing capsule must reach the highest hitbox from the fixed foot
-		# plane. This also covers authored hitboxes that stop above the soles.
-		height = maxf(padded.end.y - _floor_y, padded.size.y)
-	else:
-		# Once the body is horizontal, use the envelope's actual thickness rather
-		# than its absolute Y offset. Grounding that thickness at the stable foot
-		# plane avoids turning an authored prone pose offset into empty capsule
-		# space below the body.
-		var cross_axis_width := padded.size.z if absf(axis.x) > 0.5 else padded.size.x
-		radius = maxf(cross_axis_width, padded.size.y) * 0.5
-		height = padded.size.x if absf(axis.x) > 0.5 else padded.size.z
-
-	radius = clampf(
-		radius,
-		_config.collision_shape_radius,
-		maxf(_config.collision_bounds_max_radius, _config.collision_shape_radius)
-	)
-	var minimum_height := maxf(_config.collision_bounds_min_height, radius * 2.0)
-	height = clampf(
-		maxf(height, minimum_height),
-		minimum_height,
-		maxf(_config.collision_bounds_max_height, minimum_height)
-	)
-	center.y = _floor_y + _vertical_half_extent(height, radius, axis)
+	var fit := _fit_containing_capsule(padded, axis)
+	var radius := float(fit["radius"])
+	var height := float(fit["height"])
+	var center := fit["center"] as Vector3
 	_fit_axis = axis
 	_fit_center = center
 	_fit_height = height
 	_fit_radius = radius
+
+
+## Fits all eight AABB corners while keeping the capsule's world-facing bottom
+## on the configured floor plane. The preferred max dimensions protect against
+## ordinary animation outliers; if those limits cannot contain the supplied
+## envelope, containment wins instead of silently exposing part of the body.
+func _fit_containing_capsule(envelope: AABB, axis: Vector3) -> Dictionary:
+	var minimum_radius := maxf(_config.collision_shape_radius, 0.01)
+	var preferred_max_radius := maxf(_config.collision_bounds_max_radius, minimum_radius)
+	var preferred_max_height := maxf(
+		_config.collision_bounds_max_height,
+		_config.collision_bounds_min_height
+	)
+	var expanded_radius_limit := maxf(
+		preferred_max_radius,
+		envelope.size.length() + absf(envelope.end.y - _floor_y) + minimum_radius
+	)
+	var fit := _search_containing_fit(
+		envelope, axis, minimum_radius, preferred_max_radius, preferred_max_height
+	)
+	if fit.is_empty():
+		fit = _search_containing_fit(
+			envelope, axis, minimum_radius, expanded_radius_limit, preferred_max_height
+		)
+	if fit.is_empty():
+		# A longitudinal range larger than max_height cannot be reduced by radius.
+		# Pick the smallest exact candidate and allow height to exceed the preferred
+		# cap rather than returning a collider that misses the supplied body bounds.
+		fit = _search_containing_fit(
+			envelope, axis, minimum_radius, expanded_radius_limit, INF
+		)
+	if fit.is_empty():
+		# AABB data below the authored floor cannot be enclosed by a floor-anchored
+		# capsule. Preserve containment with an envelope-centered exact fallback;
+		# this is safer than silently returning a collider that misses body parts.
+		fit = _fit_unanchored_containing_capsule(envelope, axis, minimum_radius)
+	return fit
+
+
+func _search_containing_fit(
+	envelope: AABB,
+	axis: Vector3,
+	minimum_radius: float,
+	maximum_radius: float,
+	maximum_height: float
+) -> Dictionary:
+	var span := maxf(maximum_radius - minimum_radius, 0.0)
+	for step_index in range(FIT_SEARCH_STEPS + 1):
+		var ratio := float(step_index) / float(FIT_SEARCH_STEPS)
+		var radius := minimum_radius + span * ratio
+		var required_height := _required_height_for_radius(envelope, axis, radius)
+		if not is_finite(required_height):
+			continue
+		var height := maxf(
+			required_height,
+			maxf(_config.collision_bounds_min_height, radius * 2.0)
+		)
+		if height > maximum_height + GEOMETRY_EPSILON:
+			continue
+		var center := _floor_anchored_center(envelope, axis, height, radius)
+		if _capsule_contains_aabb(envelope, center, axis, height, radius):
+			return {"radius": radius, "height": height, "center": center}
+	return {}
+
+
+func _required_height_for_radius(envelope: AABB, axis: Vector3, radius: float) -> float:
+	var half := envelope.size * 0.5
+	if absf(axis.y) > 0.5:
+		var transverse := Vector2(half.x, half.z).length()
+		if transverse > radius + GEOMETRY_EPSILON:
+			return INF
+		var lower_height := envelope.position.y - _floor_y
+		if lower_height < -GEOMETRY_EPSILON:
+			return INF
+		var cap_reach := sqrt(maxf(radius * radius - transverse * transverse, 0.0))
+		if envelope.position.y < _floor_y + radius - cap_reach - GEOMETRY_EPSILON:
+			return INF
+		return maxf(
+			radius * 2.0,
+			envelope.end.y - _floor_y + radius - cap_reach
+		)
+
+	var cross_half := half.z if absf(axis.x) > 0.5 else half.x
+	var lower_y := envelope.position.y - _floor_y
+	var upper_y := envelope.end.y - _floor_y
+	if lower_y < -GEOMETRY_EPSILON:
+		return INF
+	var lower_perpendicular := Vector2(cross_half, lower_y - radius).length()
+	var upper_perpendicular := Vector2(cross_half, upper_y - radius).length()
+	var farthest_perpendicular := maxf(lower_perpendicular, upper_perpendicular)
+	if farthest_perpendicular > radius + GEOMETRY_EPSILON:
+		return INF
+	var cap_reach := sqrt(maxf(radius * radius - farthest_perpendicular * farthest_perpendicular, 0.0))
+	var longitudinal_half := half.x if absf(axis.x) > 0.5 else half.z
+	var segment_half := maxf(longitudinal_half - cap_reach, 0.0)
+	return (radius + segment_half) * 2.0
+
+
+func _floor_anchored_center(
+	envelope: AABB,
+	axis: Vector3,
+	height: float,
+	radius: float
+) -> Vector3:
+	var center := envelope.get_center()
+	center.y = _floor_y + _vertical_half_extent(height, radius, axis)
+	return center
+
+
+func _fit_unanchored_containing_capsule(
+	envelope: AABB,
+	axis: Vector3,
+	minimum_radius: float
+) -> Dictionary:
+	var half := envelope.size * 0.5
+	var transverse := Vector2(half.x, half.z).length()
+	var longitudinal_half := half.y
+	if absf(axis.x) > 0.5:
+		transverse = Vector2(half.y, half.z).length()
+		longitudinal_half = half.x
+	elif absf(axis.z) > 0.5:
+		transverse = Vector2(half.x, half.y).length()
+		longitudinal_half = half.z
+	var radius := maxf(minimum_radius, transverse)
+	var cap_reach := sqrt(maxf(radius * radius - transverse * transverse, 0.0))
+	var segment_half := maxf(longitudinal_half - cap_reach, 0.0)
+	var height := maxf(
+		(radius + segment_half) * 2.0,
+		maxf(_config.collision_bounds_min_height, radius * 2.0)
+	)
+	return {
+		"radius": radius,
+		"height": height,
+		"center": envelope.get_center(),
+	}
 
 
 func _fit_fallback(_snap_axis: bool) -> void:
@@ -263,14 +440,27 @@ func _apply_target(delta: float, snap: bool) -> void:
 		next_center.z = move_toward(_collision_shape.position.z, target_center.z, linear_step)
 
 	next_height = maxf(next_height, next_radius * 2.0)
-	_set_capsule_dimensions(capsule, next_height, next_radius)
-	_collision_shape.quaternion = Quaternion(Vector3.UP, next_axis).normalized()
 	next_center.y = _floor_y + _vertical_half_extent(
-		capsule.height,
-		capsule.radius,
+		next_height,
+		next_radius,
 		next_axis
 	)
+	if not _geometry_differs(capsule, next_height, next_radius, next_axis, next_center):
+		_transition_blocked_emitted = false
+		return
+	if not snap and _requires_clearance(
+		capsule, next_height, next_radius, next_axis, next_center
+	) and not _candidate_has_clearance(next_height, next_radius, next_axis, next_center):
+		if not _transition_blocked_emitted:
+			_transition_blocked_emitted = true
+			transition_blocked.emit()
+		return
+
+	_transition_blocked_emitted = false
+	_set_capsule_dimensions(capsule, next_height, next_radius)
+	_collision_shape.quaternion = Quaternion(Vector3.UP, next_axis).normalized()
 	_collision_shape.position = next_center
+	_geometry_write_count += 1
 	geometry_changed.emit(
 		capsule.height,
 		capsule.radius,
@@ -280,16 +470,80 @@ func _apply_target(delta: float, snap: bool) -> void:
 	)
 
 
+func _geometry_differs(
+	capsule: CapsuleShape3D,
+	height: float,
+	radius: float,
+	axis: Vector3,
+	center: Vector3
+) -> bool:
+	return absf(capsule.height - height) > GEOMETRY_EPSILON \
+		or absf(capsule.radius - radius) > GEOMETRY_EPSILON \
+		or get_capsule_axis().angle_to(axis) > GEOMETRY_EPSILON \
+		or _collision_shape.position.distance_to(center) > GEOMETRY_EPSILON
+
+
+func _requires_clearance(
+	capsule: CapsuleShape3D,
+	height: float,
+	radius: float,
+	axis: Vector3,
+	center: Vector3
+) -> bool:
+	var current_axis := get_capsule_axis()
+	var same_axis := current_axis.angle_to(axis) <= GEOMETRY_EPSILON
+	var same_horizontal_center := Vector2(
+		_collision_shape.position.x,
+		_collision_shape.position.z
+	).distance_to(Vector2(center.x, center.z)) <= GEOMETRY_EPSILON
+	var only_floor_anchored_shrink := same_axis \
+		and same_horizontal_center \
+		and height <= capsule.height + GEOMETRY_EPSILON \
+		and radius <= capsule.radius + GEOMETRY_EPSILON
+	return not only_floor_anchored_shrink
+
+
+func _candidate_has_clearance(
+	height: float,
+	radius: float,
+	axis: Vector3,
+	center: Vector3
+) -> bool:
+	if not _body or not _body.is_inside_tree() or not _body.get_world_3d():
+		return true
+	var query_shape := CapsuleShape3D.new()
+	var query_radius := maxf(radius - CLEARANCE_SKIN, 0.001)
+	var query_height := maxf(height - CLEARANCE_SKIN * 2.0, query_radius * 2.0)
+	query_shape.radius = query_radius
+	query_shape.height = query_height
+	var parameters := PhysicsShapeQueryParameters3D.new()
+	parameters.shape = query_shape
+	parameters.transform = _body.global_transform * Transform3D(
+		Basis(Quaternion(Vector3.UP, axis).normalized()),
+		center
+	)
+	parameters.exclude = [_body.get_rid()]
+	parameters.collision_mask = _body.collision_mask
+	parameters.collide_with_bodies = true
+	parameters.collide_with_areas = false
+	parameters.margin = 0.0
+	return _body.get_world_3d().direct_space_state.intersect_shape(parameters, 1).is_empty()
+
+
 func _set_capsule_dimensions(capsule: CapsuleShape3D, height: float, radius: float) -> void:
 	# Godot enforces height >= 2 * radius. Assignment order matters while radius
 	# grows or shrinks, otherwise the resource can silently rewrite the other
 	# property and bypass our configured per-frame limit.
 	if radius > capsule.radius:
-		capsule.height = maxf(height, radius * 2.0)
-		capsule.radius = radius
+		if absf(capsule.height - height) > GEOMETRY_EPSILON:
+			capsule.height = maxf(height, radius * 2.0)
+		if absf(capsule.radius - radius) > GEOMETRY_EPSILON:
+			capsule.radius = radius
 	else:
-		capsule.radius = radius
-		capsule.height = maxf(height, radius * 2.0)
+		if absf(capsule.radius - radius) > GEOMETRY_EPSILON:
+			capsule.radius = radius
+		if absf(capsule.height - height) > GEOMETRY_EPSILON:
+			capsule.height = maxf(height, radius * 2.0)
 
 
 func _rotate_axis_toward(current: Vector3, target: Vector3, maximum_angle: float) -> Vector3:
@@ -310,6 +564,58 @@ func _axis_extent(size: Vector3, axis: Vector3) -> float:
 	if absf(axis.z) > 0.5:
 		return size.z
 	return size.y
+
+
+func _aabb_is_equal_approx(first: AABB, second: AABB) -> bool:
+	return first.position.distance_to(second.position) <= ENVELOPE_EPSILON \
+		and first.size.distance_to(second.size) <= ENVELOPE_EPSILON
+
+
+func _aabb_corners(envelope: AABB) -> Array[Vector3]:
+	var minimum := envelope.position
+	var maximum := envelope.end
+	return [
+		Vector3(minimum.x, minimum.y, minimum.z),
+		Vector3(minimum.x, minimum.y, maximum.z),
+		Vector3(minimum.x, maximum.y, minimum.z),
+		Vector3(minimum.x, maximum.y, maximum.z),
+		Vector3(maximum.x, minimum.y, minimum.z),
+		Vector3(maximum.x, minimum.y, maximum.z),
+		Vector3(maximum.x, maximum.y, minimum.z),
+		Vector3(maximum.x, maximum.y, maximum.z),
+	]
+
+
+func _capsule_contains_aabb(
+	envelope: AABB,
+	center: Vector3,
+	axis: Vector3,
+	height: float,
+	radius: float
+) -> bool:
+	for corner in _aabb_corners(envelope):
+		if not _capsule_contains_point(
+			corner, center, axis, height, radius, GEOMETRY_EPSILON
+		):
+			return false
+	return true
+
+
+func _capsule_contains_point(
+	point: Vector3,
+	center: Vector3,
+	axis: Vector3,
+	height: float,
+	radius: float,
+	tolerance: float = 0.0
+) -> bool:
+	var normalized_axis := axis.normalized()
+	var segment_half := maxf(height * 0.5 - radius, 0.0)
+	var relative := point - center
+	var projected := clampf(relative.dot(normalized_axis), -segment_half, segment_half)
+	var nearest := center + normalized_axis * projected
+	var allowed_radius := radius + maxf(tolerance, 0.0)
+	return point.distance_squared_to(nearest) <= allowed_radius * allowed_radius
 
 
 func _envelope_is_valid(envelope: AABB) -> bool:

--- a/classes/player/stance_controller.gd
+++ b/classes/player/stance_controller.gd
@@ -25,6 +25,7 @@ var _prone_transition: bool = false
 var _prone_entering: bool = false
 var _prone_exit_to_stand: bool = false
 var _prone_timer: float = 0.0
+var _stance_before_prone: float = 0.0
 
 var _stance_value: float = 0.0  # 当前姿态（平滑插值后的值）
 var _target_stance: float = 0.0  # 目标姿态（滚轮设定的目标）
@@ -118,6 +119,35 @@ func is_prone_transitioning() -> bool:
 func get_prone_geometry_blend() -> float:
 	return _prone_geometry_blend
 
+
+## Cancels the active prone geometry transition when the composition root says
+## the candidate environment capsule has no clearance. This controller never
+## queries physics or reaches into PlayerCollisionController directly.
+func reject_collision_transition() -> void:
+	if not _prone_transition:
+		return
+	var rejected_entry := _prone_entering
+	_prone_transition = false
+	_prone_entering = false
+	_prone_exit_to_stand = false
+	_prone_timer = 0.0
+	if rejected_entry:
+		_is_prone = false
+		_target_stance = _stance_before_prone
+		_prone_geometry_target = 0.0
+		prone_changed.emit(false)
+	else:
+		_is_prone = true
+		_target_stance = 1.0
+		_prone_geometry_target = 1.0
+		prone_changed.emit(true)
+	prone_transition_changed.emit(false)
+	if _player and _player.get("animation_controller"):
+		if _is_prone:
+			_player.animation_controller.play_prone_idle()
+		else:
+			_player.animation_controller.clear_prone_override()
+
 func _unhandled_input(event: InputEvent) -> void:
 	# Prone is handled in _input so it is not affected by UI/event consumption.
 	return
@@ -125,6 +155,7 @@ func _unhandled_input(event: InputEvent) -> void:
 func _enter_prone() -> void:
 	if _prone_transition or _is_prone:
 		return
+	_stance_before_prone = _target_stance
 	_target_stance = 1.0
 	_prone_geometry_target = 1.0
 	_is_prone = true

--- a/docs/player/PlayerCollisionController.md
+++ b/docs/player/PlayerCollisionController.md
@@ -29,11 +29,13 @@ PlayerCollisionController
 3. 碰撞控制器比较包络 X/Y/Z 三轴长度。
 4. 连续稳定数帧后，最长轴成为胶囊主轴。
 5. 站立/下蹲通常选择 Y 轴；趴下包络沿 X 或 Z 更长时，同一胶囊自动平放。
-6. 胶囊半径取另外两轴所需的近似横截面，高度取主轴范围。
+6. 对 AABB 的八个角点计算到胶囊中轴线段的距离，搜索满足全部角点的最小半径/高度组合。
 
 这里没有 `if prone` 或逐动画碰撞高度表；翻滚、倒地或未来动作只要改变骨骼 hitbox 分布，就会经过同一拟合流程。
 
-医疗 hitbox 不覆盖脚底，因此胶囊的地面接触面固定在站立配置的底边。竖直胶囊使用“固定底边到最高 hitbox”的高度；水平胶囊使用包络自身的 Y 厚度并落到固定底面，避免把趴下动画的整体 Y 偏移误算成身体厚度。胶囊旋转时使用“球半径 + 中段在世界 Y 上的投影”计算真实垂直半高，再调整中心 Y；两种方向都不会把 `CharacterBody3D` 瞬间顶起或落下。
+医疗 hitbox 不覆盖脚底，因此胶囊的地面接触面固定在站立配置的底边。竖直胶囊使用“固定底边到最高 hitbox”的高度；水平胶囊也以同一底边为锚点，并同时包住 AABB 的上下、左右和前后角点。胶囊旋转时使用“球半径 + 中段在世界 Y 上的投影”计算真实垂直半高，再调整中心 Y；两种方向都不会把 `CharacterBody3D` 瞬间顶起或落下。
+
+`collision_bounds_max_height` 和 `collision_bounds_max_radius` 是正常动画数据的首选保护范围。如果首选范围无法包含输入包络，控制器会扩大搜索范围；完整包围人体优先于静默截断碰撞体。如果异常包络已经低于配置地面、导致地面锚定在数学上无解，则降级为以包络中心定位的精确胶囊，而不是漏掉身体。`contains_envelope(AABB)` 提供只读断言接口，测试会逐角验证实际胶囊。
 
 ## 防抖与限速
 
@@ -42,13 +44,17 @@ PlayerCollisionController
 | `hitbox_driven_collision` | 启用 3D hitbox 包络；关闭或无包络时使用 fallback |
 | `collision_bounds_margin` | 包络三个轴外的通用安全余量 |
 | `collision_bounds_follow_speed` | 胶囊高度、半径和水平中心每秒最大变化 |
-| `collision_bounds_min_height` / `max_height` | Godot 胶囊合法范围和异常姿态保护 |
-| `collision_bounds_max_radius` | 限制损坏动画帧造成的过宽碰撞体 |
+| `collision_bounds_min_height` / `max_height` | Godot 胶囊下限与正常数据的首选高度上限 |
+| `collision_bounds_max_radius` | 正常数据的首选半径上限；无法包围时允许扩大 |
 | `collision_axis_switch_ratio` | 新主轴相对当前轴所需的长度优势 |
 | `collision_axis_switch_stability_frames` | 主轴候选需连续稳定的物理帧；过滤单帧 T-pose |
 | `collision_axis_follow_speed_degrees` | 竖直/水平轴之间的最大旋转速度 |
 
 `CapsuleShape3D` 要求 `height >= 2 × radius`。控制器按扩大/缩小方向选择属性写入顺序，并在每帧限速内同时满足这个约束，避免 Godot 自动改写另一属性造成隐藏跳变。
+
+包络最多以 30 Hz 采样，并使用位置/尺寸 epsilon 缓存。姿态稳定且拟合结果未变化时不会写 `CapsuleShape3D`、旋转或位移，也不会重复发送 `geometry_changed`；这避免每个 bot 在 idle 时持续触发 PhysicsServer 形状更新。
+
+扩大、旋转或横向移动碰撞体之前，控制器用候选胶囊执行 `intersect_shape` 空间查询，并排除角色自身。查询失败时保持当前合法形状，只发送一次 `transition_blocked`。`BasePlayer` 作为组合根把该信号转发为 `StanceController.reject_collision_transition()`，姿态回滚到趴下或原站姿；碰撞组件和姿态组件仍不互相持有。
 
 ## Fallback
 
@@ -56,6 +62,6 @@ PlayerCollisionController
 
 ## 测试
 
-- `tests/hitbox_driven_collision_check.tscn`：验证医疗系统只发布 AABB、唯一碰撞所有权、未知 3D 包络限速，以及不传 prone 标志时自动拟合水平胶囊。
-- `tests/prone_exit_collision_check.tscn`：验证无 hitbox fallback 在趴下起身时平滑、脚底不漂移。
+- `tests/hitbox_driven_collision_check.tscn`：验证医疗系统只发布 AABB、唯一碰撞所有权、八角点包围、未知 3D 包络限速、自动拟合水平胶囊，以及 steady-state 不重复写 physics shape。
+- `tests/prone_exit_collision_check.tscn`：验证无 hitbox fallback 在趴下起身时平滑、脚底不漂移，并验证低天花板会拒绝扩张且姿态回滚。
 - `tests/live_prone_collision_check.tscn`：运行真实趴下/起身动画，检查竖直→水平→竖直主轴、半径/高度/旋转限速、相机、角色根节点和地面接触。

--- a/docs/player/PlayerCollisionController.md
+++ b/docs/player/PlayerCollisionController.md
@@ -10,8 +10,8 @@
 
 ```text
 BodyHitbox（HealthSystem 私有节点）
-        ↓ HealthSystem 内部合并
-player-local AABB 值
+        ↓ HealthSystem 合并骨骼跟随中心点
+player-local 核心姿态 AABB 值
         ↓ 注入 Callable
 PlayerCollisionController
         ↓ geometry_changed(纯数值信号)
@@ -22,26 +22,28 @@ PlayerCollisionController
 
 ## 3D 动态拟合
 
-旧实现只取 hitbox 的最低/最高 Y，无法知道趴下的人体沿地面占据多长范围。当前流程使用所有 H 键可见 `BodyHitbox` 的完整 3D 包络：
+旧实现只取 hitbox 的最低/最高 Y，无法知道趴下的人体沿地面占据多长范围。当前流程使用所有 H 键可见 `BodyHitbox` 的骨骼跟随中心形成 3D 核心包络：
 
-1. `BodyHitbox.get_bounds()` 计算单个形状在玩家局部空间中的 `AABB`。
-2. `HealthSystem.get_collision_envelope()` 合并全部 hitbox，只返回 `AABB` 值，不暴露节点。
+1. `BodyHitbox.get_center_in_space()` 读取单个形状在玩家局部空间中的中心点。
+2. `HealthSystem.get_collision_envelope()` 合并全部中心点，只返回 `AABB` 值，不暴露节点。
 3. 碰撞控制器比较包络 X/Y/Z 三轴长度。
 4. 连续稳定数帧后，最长轴成为胶囊主轴。
 5. 站立/下蹲通常选择 Y 轴；趴下包络沿 X 或 Z 更长时，同一胶囊自动平放。
-6. 对 AABB 的八个角点计算到胶囊中轴线段的距离，搜索满足全部角点的最小半径/高度组合。
+6. 对核心 AABB 的八个角点计算到胶囊中轴线段的距离，搜索满足全部角点的半径/高度组合。
+
+环境碰撞不会合并每个医疗 hitbox 的完整形状 AABB。手脚和旋转胶囊的矩形外包角点并不是角色真正占据的实体空间；把这些角点再次强制装进一个总胶囊会把站立碰撞体放大到约 2.75m，并使趴下碰撞体仍超过 1.3m。医疗命中检测继续使用完整形状，环境胶囊只消费中心点形成的骨架核心轮廓，再加统一安全余量。
 
 这里没有 `if prone` 或逐动画碰撞高度表；翻滚、倒地或未来动作只要改变骨骼 hitbox 分布，就会经过同一拟合流程。
 
 医疗 hitbox 不覆盖脚底，因此胶囊的地面接触面固定在站立配置的底边。竖直胶囊使用“固定底边到最高 hitbox”的高度；水平胶囊也以同一底边为锚点，并同时包住 AABB 的上下、左右和前后角点。胶囊旋转时使用“球半径 + 中段在世界 Y 上的投影”计算真实垂直半高，再调整中心 Y；两种方向都不会把 `CharacterBody3D` 瞬间顶起或落下。
 
-`collision_bounds_max_height` 和 `collision_bounds_max_radius` 是正常动画数据的首选保护范围。如果首选范围无法包含输入包络，控制器会扩大搜索范围；完整包围人体优先于静默截断碰撞体。如果异常包络已经低于配置地面、导致地面锚定在数学上无解，则降级为以包络中心定位的精确胶囊，而不是漏掉身体。`contains_envelope(AABB)` 提供只读断言接口，测试会逐角验证实际胶囊。
+`collision_bounds_max_height` 和 `collision_bounds_max_radius` 是正常动画数据的首选保护范围。如果首选范围无法包含输入包络，控制器会扩大搜索范围；完整包围输入的核心姿态优先于静默截断。如果异常包络已经低于配置地面、导致地面锚定在数学上无解，则降级为以包络中心定位的精确胶囊。`contains_envelope(AABB)` 提供只读断言接口，测试会逐角验证实际胶囊。
 
 ## 防抖与限速
 
 | 字段 | 作用 |
 |---|---|
-| `hitbox_driven_collision` | 启用 3D hitbox 包络；关闭或无包络时使用 fallback |
+| `hitbox_driven_collision` | 启用 3D hitbox 中心核心包络；关闭或无包络时使用 fallback |
 | `collision_bounds_margin` | 包络三个轴外的通用安全余量 |
 | `collision_bounds_follow_speed` | 胶囊高度、半径和水平中心每秒最大变化 |
 | `collision_bounds_min_height` / `max_height` | Godot 胶囊下限与正常数据的首选高度上限 |
@@ -64,4 +66,4 @@ PlayerCollisionController
 
 - `tests/hitbox_driven_collision_check.tscn`：验证医疗系统只发布 AABB、唯一碰撞所有权、八角点包围、未知 3D 包络限速、自动拟合水平胶囊，以及 steady-state 不重复写 physics shape。
 - `tests/prone_exit_collision_check.tscn`：验证无 hitbox fallback 在趴下起身时平滑、脚底不漂移，并验证低天花板会拒绝扩张且姿态回滚。
-- `tests/live_prone_collision_check.tscn`：运行真实趴下/起身动画，检查竖直→水平→竖直主轴、半径/高度/旋转限速、相机、角色根节点和地面接触。
+- `tests/live_prone_collision_check.tscn`：运行真实趴下/起身动画，检查竖直→水平→竖直主轴、合理的站/趴垂直尺寸、半径/高度/旋转限速、相机三维单帧位移、角色根节点、空地 clearance 判定和地面接触。

--- a/tests/hitbox_driven_collision_check.gd
+++ b/tests/hitbox_driven_collision_check.gd
@@ -46,6 +46,9 @@ func _run() -> void:
 	if not _check(controller.get_capsule_axis().dot(Vector3.UP) > 0.999,
 		"standing 3D envelope fits a vertical capsule"):
 		return
+	if not _check(controller.contains_envelope(source["envelope"] as AABB),
+		"standing capsule contains every supplied AABB corner"):
+		return
 	if not _check(absf(controller.get_floor_contact_y() + 0.9) < 0.001,
 		"fitted capsule preserves configured floor contact"):
 		return
@@ -73,8 +76,9 @@ func _run() -> void:
 	# physics write is observed through the public signal and must remain bounded.
 	source["envelope"] = AABB(Vector3(-0.4, -0.85, -0.35), Vector3(0.8, 2.0, 0.7))
 	controller.set_physics_process(true)
-	await get_tree().physics_frame
-	await get_tree().process_frame
+	for _frame in 3:
+		await get_tree().physics_frame
+		await get_tree().process_frame
 	controller.set_physics_process(false)
 	var maximum_step := controller._config.collision_bounds_follow_speed / 60.0 + 0.002
 	if not _check(
@@ -83,14 +87,19 @@ func _run() -> void:
 		"unknown 3D envelope changes remain bounded per physics tick"
 	):
 		return
+	if not _check(
+		float(metrics["height_step"]) > 0.0 or float(metrics["radius_step"]) > 0.0,
+		"unknown 3D envelope changes produce a sampled geometry update"
+	):
+		return
 	var bounded_height_step := float(metrics["height_step"])
 	var bounded_radius_step := float(metrics["radius_step"])
 
 	# A prone-like envelope is longer along Z than Y. No prone flag or animation
 	# name is supplied: the fit must infer a horizontal capsule from geometry.
 	var prone_envelope := AABB(
-		Vector3(-0.35, -0.85, -1.1),
-		Vector3(0.7, 0.55, 2.2)
+		Vector3(-0.35, -0.6, -1.1),
+		Vector3(0.7, 0.45, 2.2)
 	)
 	source["envelope"] = prone_envelope
 	controller.refresh_immediately()
@@ -101,6 +110,9 @@ func _run() -> void:
 	if not _check(capsule.height >= prone_envelope.size.z,
 		"horizontal capsule follows the prone body's longitudinal range"):
 		return
+	if not _check(controller.contains_envelope(prone_envelope),
+		"horizontal capsule contains every supplied AABB corner"):
+		return
 	if not _check(controller.get_vertical_extent() < 1.0,
 		"prone capsule keeps a low vertical profile"):
 		return
@@ -108,11 +120,56 @@ func _run() -> void:
 		"horizontal capsule also preserves floor contact"):
 		return
 
-	print("hitbox_driven_collision_check=ok medical_size=%s prone_axis=%s height_step=%.4f radius_step=%.4f" % [
+	# An unchanged pose may still be sampled at the controller's throttled rate,
+	# but it must not rewrite the shared physics shape on every physics tick.
+	var writes_before_idle := controller.get_geometry_write_count()
+	var samples_before_idle := controller.get_envelope_sample_count()
+	controller.set_physics_process(true)
+	for _frame in 12:
+		await get_tree().physics_frame
+	controller.set_physics_process(false)
+	var idle_samples := controller.get_envelope_sample_count() - samples_before_idle
+	if not _check(controller.get_geometry_write_count() == writes_before_idle,
+		"steady poses do not rewrite CapsuleShape3D"):
+		return
+	if not _check(idle_samples > 0 and idle_samples <= 8,
+		"steady poses sample the hitbox envelope at a bounded rate"):
+		return
+
+	# Model a small bot squad with independent bodies/controllers. Sixty steady
+	# physics steps must produce no shape-server writes after the initial fit.
+	var bot_controllers: Array[PlayerCollisionController] = []
+	for bot_index in 16:
+		var bot_body := CharacterBody3D.new()
+		bot_body.name = "SteadyBotBody%d" % bot_index
+		map.add_child(bot_body)
+		var bot_controller := PlayerCollisionController.new()
+		bot_controller.name = "CollisionController"
+		bot_body.add_child(bot_controller)
+		bot_controller.initialize(bot_body, controller._config, envelope_provider)
+		bot_controller.set_physics_process(false)
+		bot_controller.refresh_immediately()
+		bot_controllers.append(bot_controller)
+	var squad_writes_before := 0
+	for bot_controller in bot_controllers:
+		squad_writes_before += bot_controller.get_geometry_write_count()
+	for frame_index in 60:
+		for bot_controller in bot_controllers:
+			bot_controller._update_geometry(1.0 / 60.0, false, frame_index % 2 == 0)
+	var squad_writes_after := 0
+	for bot_controller in bot_controllers:
+		squad_writes_after += bot_controller.get_geometry_write_count()
+	if not _check(squad_writes_after == squad_writes_before,
+		"steady multi-bot squad performs zero repeated physics-shape writes"):
+		return
+
+	print("hitbox_driven_collision_check=ok medical_size=%s prone_axis=%s height_step=%.4f radius_step=%.4f idle_samples=%d steady_bots=%d" % [
 		medical_envelope.size,
 		prone_axis,
 		bounded_height_step,
 		bounded_radius_step,
+		idle_samples,
+		bot_controllers.size(),
 	])
 	controller.geometry_changed.disconnect(geometry_observer)
 	map.queue_free()

--- a/tests/hitbox_driven_collision_check.gd
+++ b/tests/hitbox_driven_collision_check.gd
@@ -23,7 +23,7 @@ func _run() -> void:
 	var capsule := collision.shape as CapsuleShape3D
 	var medical_envelope := player.health_system.get_collision_envelope()
 	if not _check(_valid_envelope(medical_envelope),
-		"medical system publishes a value-only 3D hitbox envelope"):
+		"medical system publishes a value-only 3D core-pose envelope"):
 		return
 	var environment_shape_count := 0
 	for child in player.get_children():
@@ -72,8 +72,9 @@ func _run() -> void:
 		metrics["previous_radius"] = radius
 	controller.geometry_changed.connect(geometry_observer)
 
-	# Simulate an unseen animation increasing the full body envelope. Each actual
-	# physics write is observed through the public signal and must remain bounded.
+	# Simulate an unseen animation increasing the supplied core-pose envelope.
+	# Each actual physics write is observed through the public signal and must
+	# remain bounded.
 	source["envelope"] = AABB(Vector3(-0.4, -0.85, -0.35), Vector3(0.8, 2.0, 0.7))
 	controller.set_physics_process(true)
 	for _frame in 3:

--- a/tests/live_prone_collision_check.gd
+++ b/tests/live_prone_collision_check.gd
@@ -77,8 +77,11 @@ func _run() -> void:
 	if not _check(absf(prone_axis.y) < 0.35,
 		"live prone hitbox envelope rotates the capsule horizontally"):
 		return
-	if not _check(prone_vertical_extent < standing_vertical_extent - 0.2,
-		"live prone capsule has a lower vertical profile"):
+	if not _check(controller.contains_envelope(prone_envelope, 0.005),
+		"live prone capsule contains the complete hitbox envelope"):
+		return
+	if not _check(prone_vertical_extent <= player.player_config.collision_bounds_max_radius * 2.0 + 0.05,
+		"live prone capsule stays within the preferred transverse profile"):
 		return
 
 	active["metrics"] = _new_geometry_metrics(capsule, prone_axis)
@@ -90,9 +93,6 @@ func _run() -> void:
 	var restored_axis := controller.get_capsule_axis()
 	if not _check(restored_axis.dot(Vector3.UP) > 0.9,
 		"live standing envelope restores the vertical capsule axis"):
-		return
-	if not _check(controller.get_vertical_extent() > prone_vertical_extent + 0.2,
-		"live standing envelope restores occupied height"):
 		return
 
 	var maximum_linear_step := player.player_config.collision_bounds_follow_speed / 60.0 + 0.003

--- a/tests/live_prone_collision_check.gd
+++ b/tests/live_prone_collision_check.gd
@@ -26,15 +26,21 @@ func _run() -> void:
 	if not _check(stance != null and capsule != null and camera != null, "live prone dependencies initialize"):
 		return
 
-	for _frame in 20:
+	for _frame in 120:
 		await get_tree().physics_frame
 	var standing_vertical_extent := controller.get_vertical_extent()
 	var standing_axis := controller.get_capsule_axis()
 	var standing_radius := capsule.radius
 	var root_y := player.global_position.y
+	var standing_camera_local := player.global_transform.affine_inverse() * camera.global_position
 	var expected_floor_y := controller.get_floor_contact_y()
 	if not _check(standing_axis.dot(Vector3.UP) > 0.9,
 		"live standing hitbox envelope selects a vertical capsule"):
+		return
+	if not _check(
+		standing_vertical_extent <= player.player_config.collision_shape_height + 0.15,
+		"standing core envelope does not inflate the environment capsule"
+	):
 		return
 
 	# Observe the controller's public signal. This records every actual physics
@@ -42,6 +48,9 @@ func _run() -> void:
 	var active := {
 		"metrics": _new_geometry_metrics(capsule, standing_axis),
 	}
+	var blocked := {"count": 0}
+	var blocked_observer := func() -> void:
+		blocked["count"] = int(blocked["count"]) + 1
 	var geometry_observer := func(height: float, radius: float, axis: Vector3, _center: Vector3, floor_y: float) -> void:
 		var metrics := active["metrics"] as Dictionary
 		metrics["height_step"] = maxf(
@@ -64,6 +73,7 @@ func _run() -> void:
 		metrics["previous_radius"] = radius
 		metrics["previous_axis"] = axis
 	controller.geometry_changed.connect(geometry_observer)
+	controller.transition_blocked.connect(blocked_observer)
 
 	stance._enter_prone()
 	var enter_camera_metrics := await _sample_transition(player, camera, 180)
@@ -74,14 +84,18 @@ func _run() -> void:
 	var prone_axis := controller.get_capsule_axis()
 	var prone_radius := capsule.radius
 	var prone_envelope := player.health_system.get_collision_envelope()
+	var prone_camera_local := player.global_transform.affine_inverse() * camera.global_position
 	if not _check(absf(prone_axis.y) < 0.35,
 		"live prone hitbox envelope rotates the capsule horizontally"):
 		return
 	if not _check(controller.contains_envelope(prone_envelope, 0.005),
-		"live prone capsule contains the complete hitbox envelope"):
+		"live prone capsule contains the complete core-pose envelope"):
 		return
-	if not _check(prone_vertical_extent <= player.player_config.collision_bounds_max_radius * 2.0 + 0.05,
-		"live prone capsule stays within the preferred transverse profile"):
+	if not _check(prone_vertical_extent <= standing_vertical_extent * 0.7,
+		"live prone capsule is materially lower than the standing capsule"):
+		return
+	if not _check(prone_camera_local.y <= standing_camera_local.y - 0.35,
+		"camera follows the head down into the prone pose"):
 		return
 
 	active["metrics"] = _new_geometry_metrics(capsule, prone_axis)
@@ -91,8 +105,15 @@ func _run() -> void:
 	if not _check(not stance.is_prone_transitioning() and not stance.is_prone(), "live prone exit completes"):
 		return
 	var restored_axis := controller.get_capsule_axis()
+	var restored_camera_local := player.global_transform.affine_inverse() * camera.global_position
 	if not _check(restored_axis.dot(Vector3.UP) > 0.9,
 		"live standing envelope restores the vertical capsule axis"):
+		return
+	if not _check(absf(restored_camera_local.y - standing_camera_local.y) < 0.2,
+		"camera returns to the standing eye-height range after prone exit"):
+		return
+	if not _check(int(blocked["count"]) == 0,
+		"ordinary open-space prone transitions are not rejected by clearance checks"):
 		return
 
 	var maximum_linear_step := player.player_config.collision_bounds_follow_speed / 60.0 + 0.003
@@ -118,24 +139,44 @@ func _run() -> void:
 	if not _check(absf(player.global_position.y - root_y) < 0.02,
 		"CharacterBody root does not fall or get pushed up by capsule fitting"):
 		return
-	if not _check(float(exit_camera_metrics["camera_step"]) < 0.08,
-		"camera-bearing head pose has no single-frame exit jump"):
+	if not _check(
+		maxf(
+			float(enter_camera_metrics["camera_step"]),
+			float(exit_camera_metrics["camera_step"])
+		) < 0.08,
+		"camera-bearing head pose has no single-frame transition jump"
+	):
+		return
+	if not _check(
+		maxf(
+			float(enter_camera_metrics["camera_position_step"]),
+			float(exit_camera_metrics["camera_position_step"])
+		) < 0.1,
+		"camera has no single-frame 3D position jump during prone transitions"
+	):
 		return
 
-	print("live_prone_collision_check=ok prone_axis=%s prone_envelope=%s@%s standing_radius=%.3f prone_radius=%.3f height_step=%.4f radius_step=%.4f axis_step_deg=%.2f camera_step=%.4f floor_drift=%.4f root_drift=%.4f" % [
+	print("live_prone_collision_check=ok prone_axis=%s prone_envelope=%s@%s standing_extent=%.3f prone_extent=%.3f standing_radius=%.3f prone_radius=%.3f height_step=%.4f radius_step=%.4f axis_step_deg=%.2f camera_step=%.4f camera_3d_step=%.4f floor_drift=%.4f root_drift=%.4f" % [
 		prone_axis,
 		prone_envelope.size,
 		prone_envelope.position,
+		standing_vertical_extent,
+		prone_vertical_extent,
 		standing_radius,
 		prone_radius,
 		_max_metric(enter_geometry_metrics, exit_geometry_metrics, "height_step"),
 		_max_metric(enter_geometry_metrics, exit_geometry_metrics, "radius_step"),
 		rad_to_deg(_max_metric(enter_geometry_metrics, exit_geometry_metrics, "axis_step")),
-		float(exit_camera_metrics["camera_step"]),
+		maxf(float(enter_camera_metrics["camera_step"]), float(exit_camera_metrics["camera_step"])),
+		maxf(
+			float(enter_camera_metrics["camera_position_step"]),
+			float(exit_camera_metrics["camera_position_step"])
+		),
 		_max_metric(enter_geometry_metrics, exit_geometry_metrics, "floor_drift"),
 		absf(player.global_position.y - root_y),
 	])
 	controller.geometry_changed.disconnect(geometry_observer)
+	controller.transition_blocked.disconnect(blocked_observer)
 	map.queue_free()
 	await get_tree().process_frame
 	await get_tree().physics_frame
@@ -155,16 +196,20 @@ func _new_geometry_metrics(capsule: CapsuleShape3D, axis: Vector3) -> Dictionary
 
 
 func _sample_transition(player: BasePlayer, camera: Camera3D, maximum_frames: int) -> Dictionary:
-	var previous_camera_y := camera.global_position.y
-	var metrics := {"camera_step": 0.0}
+	var previous_camera_position := camera.global_position
+	var metrics := {"camera_step": 0.0, "camera_position_step": 0.0}
 	for _frame in maximum_frames:
 		await get_tree().physics_frame
 		await get_tree().process_frame
 		metrics["camera_step"] = maxf(
 			float(metrics["camera_step"]),
-			absf(camera.global_position.y - previous_camera_y)
+			absf(camera.global_position.y - previous_camera_position.y)
 		)
-		previous_camera_y = camera.global_position.y
+		metrics["camera_position_step"] = maxf(
+			float(metrics["camera_position_step"]),
+			camera.global_position.distance_to(previous_camera_position)
+		)
+		previous_camera_position = camera.global_position
 		if not player.stance_controller.is_prone_transitioning() \
 			and is_equal_approx(
 				player.stance_controller._prone_geometry_blend,

--- a/tests/prone_exit_collision_check.gd
+++ b/tests/prone_exit_collision_check.gd
@@ -93,8 +93,57 @@ func _run() -> void:
 	if not _check(max_bottom_drift < 0.002, "capsule bottom remains anchored while standing up"):
 		return
 
-	print("prone_exit_collision_check=ok height_step=%.4f center_step=%.4f model_step=%.4f bottom_drift=%.4f" % [
-		max_height_step, max_center_step, max_model_step, max_bottom_drift
+	# Reset to prone, then put a low ceiling above the current capsule. The exit
+	# may approach the obstacle but must never commit an overlapping expansion;
+	# BasePlayer should translate the rejection into a public stance rollback.
+	stance._is_prone = true
+	stance._prone_transition = false
+	stance._stance_value = 1.0
+	stance._target_stance = 1.0
+	stance._prone_geometry_blend = 1.0
+	stance._prone_geometry_target = 1.0
+	stance.prone_geometry_changed.emit(1.0)
+	collision_controller.refresh_immediately()
+	var ceiling := StaticBody3D.new()
+	ceiling.name = "ProneExitClearanceCeiling"
+	var ceiling_collision := CollisionShape3D.new()
+	var ceiling_box := BoxShape3D.new()
+	ceiling_box.size = Vector3(2.0, 0.2, 2.0)
+	ceiling_collision.shape = ceiling_box
+	ceiling.add_child(ceiling_collision)
+	map.add_child(ceiling)
+	var floor_world_y := player.global_position.y + collision_controller.get_floor_contact_y()
+	var ceiling_bottom_y := floor_world_y + 0.8
+	ceiling.global_position = Vector3(
+		player.global_position.x,
+		ceiling_bottom_y + ceiling_box.size.y * 0.5,
+		player.global_position.z
+	)
+	await get_tree().physics_frame
+	var blocked := {"count": 0}
+	var count_block := func() -> void:
+		blocked["count"] = int(blocked["count"]) + 1
+	collision_controller.transition_blocked.connect(count_block)
+	stance._exit_prone(true)
+	for _frame in 60:
+		stance._process(1.0 / 60.0)
+		collision_controller._update_geometry(1.0 / 60.0, false)
+		await get_tree().physics_frame
+		if int(blocked["count"]) > 0:
+			break
+	var capsule_top_world_y := player.global_position.y + collision.position.y \
+		+ collision_controller.get_vertical_extent() * 0.5
+	if not _check(int(blocked["count"]) == 1, "blocked prone exit emits one rejection"):
+		return
+	if not _check(stance.is_prone() and not stance.is_prone_transitioning(),
+		"blocked prone exit rolls stance back to settled prone"):
+		return
+	if not _check(capsule_top_world_y <= ceiling_bottom_y + 0.005,
+		"blocked prone exit never commits an overlapping capsule"):
+		return
+
+	print("prone_exit_collision_check=ok height_step=%.4f center_step=%.4f model_step=%.4f bottom_drift=%.4f blocked=%d" % [
+		max_height_step, max_center_step, max_model_step, max_bottom_drift, int(blocked["count"])
 	])
 	get_tree().quit(0)
 


### PR DESCRIPTION
## What changed

- fit every supplied environment-envelope corner with a mathematically containing capsule
- derive the live environment envelope from bone-following hitbox centers instead of the rectangular AABBs of every medical hit volume
- query surrounding physics geometry before expanding or rotating the capsule, and roll blocked prone transitions back through the composition root
- throttle envelope sampling and suppress unchanged physics-shape writes, including a 16-bot steady-state regression
- refresh the title/main menu layout while preserving the existing dark gray and gold visual theme
- document the collision ownership, containment, clearance, caching, and core-envelope boundary

## Why

The first exact-containment implementation consumed the union of full medical shape AABBs. Their rotated rectangular corners greatly overstated occupied space, producing an approximately 2.75 m standing collider and a 1.33 m prone collider. That left the original prone problem effectively unfixed and could disturb the camera during stance changes. Medical hit detection still uses full shapes; the single environment capsule now follows their bone anchors plus a safety margin.

The branch also fixes blocked expansion under ceilings, steady-state physics-shape rewrites, and the title menu's fixed-resolution layout and weak hierarchy.

## Validation

- `hitbox_driven_collision_check` (exact supplied-AABB containment and 16 steady bots)
- `prone_exit_collision_check` (smooth exit and blocked low-ceiling rollback)
- `live_prone_collision_check` (1.81 m standing / 1.10 m prone profile, no open-space false block, 4.5 cm maximum single-frame camera movement, zero root drift)
- `prone_controls_check`
- `ragdoll_camera_check`
- `combat_effects_check`
- `ai_player_manager_check`
- Godot headless editor project scan
- `git diff --check`
- visual prone-entry and prone-exit inspection in the running TestMap
- visual inspection of the main menu and loading transition at 2560×1440
