### PR TITLE
docs: AI、遭遇战、弹道三个子系统的概览文档

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,9 @@
 
 - [Player 系统](#player-系统)
 - [医疗与伤害系统](#医疗与伤害系统)
+- [弹道与战斗系统](#弹道与战斗系统)
+- [AI 系统](#ai-系统)
+- [遭遇战系统](#遭遇战系统)
 - [UI 系统](#ui-系统)
 - [Weapon 核心](#weapon-核心)
 - [Weapon 配件](#weapon-配件)
@@ -135,6 +138,60 @@ BaseWeapon
 | 文档 | 核心文件 | 说明 |
 |------|----------|------|
 | [Medical & Anatomy System](player/MedicalSystem.md) | `classes/player/medical/health_system.gd` | P1/P2 伤害管线、27 结构解剖模型、伤道、器官损伤、骨折、内外出血与调试工具 |
+
+---
+
+## 弹道与战斗系统
+
+| 文档 | 说明 |
+|------|------|
+| [弹道系统概览](combat/BallisticsSystemOverview.md) | 飞行时间弹丸、分段射线、穿透跳弹、动能驱动伤害 |
+
+| 类 | 文件 | 说明 |
+|---|---|---|
+| BallisticProjectileSystem | `classes/combat/ballistic_projectile_system.gd` | 在飞弹丸的统一模拟（阻力/重力/风偏/偏流） |
+| Ballistics | `classes/combat/ballistics.gd` | 纯静态弹道数学工具 |
+| Projectile | `classes/combat/projectile.gd` | 瞬时 hitscan 回退路径 |
+| BallisticEnvironmentConfig | `classes/combat/ballistic_environment_config.gd` | 大气参数与仿真上限 |
+| BallisticSurfaceConfig | `classes/combat/ballistic_surface_config.gd` | 材质穿透与跳弹参数 |
+| HitResolver | `classes/combat/hit_resolver.gd` | 命中结果 → DamageInfo（存活/尸体双路径） |
+| BodyHitbox | `classes/combat/body_hitbox.gd` | 存活时的身体部位命中区 |
+
+---
+
+## AI 系统
+
+| 文档 | 说明 |
+|------|------|
+| [AI 系统概览](ai/AISystemOverview.md) | 分层职责、状态机、感知模型、黑板通信 |
+| [AI 配置说明](ai_player_configuration.md) | AIPlayer 配置装载 |
+
+| 类 | 文件 | 说明 |
+|---|---|---|
+| AIPlayerManager | `classes/bot/ai_player_manager.gd` | 地图级工厂与注册表、分帧模型加载 |
+| AIPlayerBrain | `classes/bot/ai_player_brain.gd` | 个体状态机与感知-决策-执行循环 |
+| AISquadCommander | `classes/bot/ai_squad_commander.gd` | 队长选举与掩护/突击位分配 |
+| AIBlackboard | `classes/bot/ai_blackboard.gd` | 小队共享情报（唯一通信面） |
+| AIProfile | `classes/bot/ai_profile.gd` | 行为参数资源（感知/移动/火控/战术） |
+| AIConfig | `classes/bot/ai_config.gd` | 玩法配置包 |
+| AINavigationService | `classes/bot/ai_navigation_service.gd` | 导航外观层 |
+
+---
+
+## 遭遇战系统
+
+| 文档 | 说明 |
+|------|------|
+| [遭遇战系统概览](encounter/EncounterSystemOverview.md) | 对局状态机、目标点控制、撤离决策、与 AI 的接线 |
+
+| 类 | 文件 | 说明 |
+|---|---|---|
+| EncounterRules | `classes/encounter/encounter_rules.gd` | 纯规则状态机（无场景依赖） |
+| EncounterController | `classes/encounter/encounter_controller.gd` | 场景层接线（Zone / HUD / AI） |
+| EncounterConfig | `classes/encounter/encounter_config.gd` | 对局参数资源 |
+| EncounterZone | `classes/encounter/encounter_zone.gd` | 目标点/撤离点区域 |
+| EncounterAIDirector | `classes/encounter/encounter_ai_director.gd` | 对局状态 → AI 黑板 |
+| MedicalTreatmentComponent | `classes/encounter/medical_treatment_component.gd` | 队友互救动作 |
 
 ---
 

--- a/docs/ai/AISystemOverview.md
+++ b/docs/ai/AISystemOverview.md
@@ -1,0 +1,100 @@
+# AI 系统概览
+
+## 核心理念
+
+**AI 不是"敌人脚本"，而是复用玩家实体的另一名参与者。** `AIPlayer` 继承同一个 `BasePlayer`，走同一套 `PlayerMovementController`、`WeaponManager`、`HealthSystem` 和 `PlayerRagdollSystem`。AI 没有专用的移动积分、专用的射击通路或专用的伤害计算——它只是不接受键鼠输入，改由 `AIPlayerBrain` 驱动同样的接口。
+
+这条约束换来两件事：玩家身上任何一次调参（后坐、姿态速度、失血惩罚）自动作用于 AI；反过来，AI 暴露出的物理/医疗缺陷也一定是玩家会遇到的缺陷。
+
+**信息流经黑板，不经节点引用。** 队友之间不互相持有引用、不直接读对方的 `_target`。所有战术信息（发现敌人、遭受火力、请求掩护、撤退命令）都发布到本小队的 `AIBlackboard`，其他成员从黑板读。这让"班组通信"成为可替换的一层，也为将来接入网络留下唯一的收敛点。
+
+## 文件结构
+
+```
+classes/bot/
+├── ai_player_manager.gd     ← 地图级工厂与注册表：生成/回收/分帧加载
+├── ai_player_brain.gd       ← 单个 AI 的状态机与感知-决策-执行循环
+├── ai_squad_commander.gd    ← 小队级：选举队长、分配掩护/突击位
+├── ai_blackboard.gd         ← 小队共享情报（唯一的通信面）
+├── ai_profile.gd            ← 行为参数资源（感知/移动/火控/战术）
+├── ai_config.gd             ← 玩法配置包：Profile + 阵营 + 装备
+└── limbo/limbo_bot_tick.gd  ← 行为树 tick 适配
+
+classes/player/ai_player.gd  ← BasePlayer 的 AI 特化入口
+```
+
+## 分层职责
+
+```text
+AIPlayerManager        地图级：谁存在、何时生成、模型分帧加载
+        ↓ 持有
+AISquadCommander       小队级：队长选举、掩护/突击位分配
+        ↓ 读写
+AIBlackboard           情报级：敌情、火力、掩护请求、撤退令
+        ↑ 读写
+AIPlayerBrain          个体级：感知 → 状态机 → 调用 BasePlayer 接口
+        ↓ 调用
+BasePlayer             与玩家完全相同的移动/武器/医疗实体
+```
+
+四层之间只向下调用、向上发布，不跨层反向持有。`AIPlayerBrain` 不知道 `EncounterController` 的存在；它只知道黑板上有没有目标点和撤退令。
+
+## 状态机
+
+`AIPlayerBrain.State` 共 15 个状态：
+
+| 分组 | 状态 | 说明 |
+|---|---|---|
+| 机动 | `IDLE` / `MOVE_TO_OBJECTIVE` / `PATROL_OBJECTIVE` / `SEARCH` | 无敌情时的推进与巡逻 |
+| 交火 | `ENGAGE` / `SUPPRESS` | 直接射击与压制射击 |
+| 掩护 | `TAKE_COVER` / `MOVE_UNDER_COVER` | 进入掩体、交替掩护移动 |
+| 班组 | `RESCUE` / `RETREAT` / `HOLD_EXTRACTION` | 救援倒地队友、撤退、固守撤离点 |
+| 武器 | `RELOAD` / `CLEAR_MALFUNCTION` | 换弹与排障，走玩家同一套接口 |
+| 生命 | `DOWNED` / `DEAD` | 由 `HealthSystem` 状态驱动，非 AI 自行决定 |
+
+`DOWNED` 与 `DEAD` 不由决策逻辑进入——它们是 `HealthSystem` 医疗状态的投影。这保证"AI 濒死"和"玩家濒死"是同一套判定，不会出现 AI 靠特殊分支免疫失血的情况。
+
+## 感知
+
+感知不是全知查询，而是三重过滤：
+
+1. **距离** — `perception_distance`（默认 32m）
+2. **视野角** — `field_of_view_degrees`（默认 120°），`_within_fov()`
+3. **视线** — `_can_see()` 发射线，`_get_visibility_exclusions()` 排除自身碰撞体
+
+三者全部通过才算"看见"。看见之后仍不立即开火：`reaction_time`（默认 0.25s）模拟反应延迟，`sight_check_interval`（0.20s）限制射线频率避免每帧开销。目标离开视野后由 `target_memory_time`（5s）维持记忆，超时才丢失——这是 AI 会朝最后已知位置搜索而不是瞬间遗忘的原因。
+
+命中不是完美的：`aim_error_degrees`（默认 3°）在开火方向上施加锥形误差，`_apply_aim_error()` 每次开火重新采样。
+
+## AIProfile 参数
+
+`AIProfile` 是纯资源，按需在编辑器里派生出"新兵/老兵/精锐"等档位，不需要改代码。
+
+| 分组 | 关键字段 | 作用 |
+|---|---|---|
+| Perception | `perception_distance` / `field_of_view_degrees` / `reaction_time` / `target_memory_time` / `aggression` | 何时发现、多快反应、记多久 |
+| Movement | `move_speed` / `chase_distance` / `replan_interval` / `local_avoidance_distance` / `run_to_objective` / `crouch_in_combat` | 推进方式与重规划频率 |
+| Fire Control | `weapon_distance` / `aim_error_degrees` / `burst_length` / `fire_interval` / `minimum_ammo_ratio` | 交火距离、精度与节奏 |
+| Team Tactics | 掩护/突击分配相关 | 小队协同行为 |
+
+`minimum_ammo_ratio` 决定 AI 在余弹低于该比例时主动进入 `RELOAD`，而不是打空后被动换弹——这是 AI 看起来"有战术素养"的主要来源之一。
+
+## 导航
+
+`AINavigationService` 是导航外观层，AI 只向它请求路径，不直接操作 `NavigationAgent3D`。地图使用作者手工摆放的 `NavigationRegion3D`。`replan_interval`（0.35s）限制重规划频率；`local_avoidance_distance` 处理近距离绕行，避免小队成员互相卡住。
+
+移动最终仍然写进 `PlayerMovementController`——AI 走的是玩家的加速度、步态波动与转向减速，因此 AI 的移动手感天然与玩家一致。
+
+## 分帧生成
+
+`AIPlayerManager` 支持 `defer_ai_model_load`：一次生成多个 AI 时，模型与装备实例化被排进后续帧，避免同一帧内多套场景树同时构建造成明显卡顿。`BasePlayer.ai_runtime_ready` 信号在该 AI 真正可用时发出。
+
+## 与遭遇战系统的关系
+
+AI 系统本身不定义胜负、目标或撤离。它只消费黑板上的 `objective_position` / `extraction_position` / `retreat_order`。这些值由 [遭遇战系统](../encounter/EncounterSystemOverview.md) 的 `EncounterAIDirector` 写入。
+
+因此可以在没有 `EncounterController` 的场景里单独生成 AI 做射击测试，它们会停留在 `IDLE` / `PATROL_OBJECTIVE`，不会报错。
+
+## 调试
+
+控制台（`` ` `` 键）提供 AI 生成与控制指令；`tests/` 下有 `ai_config_check.gd` 等脚本覆盖配置装载与行为断言。

--- a/docs/combat/BallisticsSystemOverview.md
+++ b/docs/combat/BallisticsSystemOverview.md
@@ -1,0 +1,104 @@
+# 弹道系统概览
+
+## 核心理念
+
+**没有"伤害值"这个字段。** 弹头只携带质量、速度、弹道系数三个物理量；伤害是命中瞬间由动能 `KE = ½mv²` 现算出来的。因此远距离命中天然更轻、短枪管天然更弱、换更重的弹头天然更狠——这些都不是配表调出来的，是同一条公式的副产品。
+
+**弹丸是数据，不是节点。** 所有在飞弹丸存在于 `BallisticProjectileSystem` 的一个 `Array[Dictionary]` 中，由单个 `Node` 统一推进。全自动连射时不会产生几十个场景节点，也就没有节点创建/销毁的帧率尖峰。
+
+## 文件结构
+
+```
+classes/combat/
+├── ballistic_projectile_system.gd   ← 飞行时间弹丸的统一模拟器
+├── ballistics.gd                    ← 纯静态弹道数学（动能/阻力/偏流）
+├── projectile.gd                    ← 瞬时 hitscan 路径（回退方案）
+├── ballistic_environment_config.gd  ← 大气与仿真上限
+├── ballistic_surface_config.gd      ← 表面穿透/跳弹参数
+├── hit_resolver.gd                  ← 命中 → DamageInfo
+├── body_hitbox.gd                   ← 存活时的身体部位命中区
+├── hitbox_config.gd                 ← 各部位碰撞体形状参数
+├── environment_impact_effect.gd     ← 环境命中特效
+├── decal_atlas_cache.gd             ← 弹孔贴花图集缓存
+└── combat_effects.gd                ← 战斗特效聚合
+```
+
+## 一发子弹的生命周期
+
+```text
+BaseWeapon._fire_one_round()
+        ↓ 读取已装 BarrelConfig（初速/弹头质量/弹道系数）
+BallisticProjectileSystem.spawn()
+        ↓ 每物理帧
+    ├── 空气阻力      dv/dt = −k·v²，k 由弹道系数推导
+    ├── 重力下坠      environment_config.gravity_mps2
+    ├── 风偏          wind_velocity_mps
+    ├── 自转偏流      膛线方向 × 飞行时间
+    └── 分段射线      本帧扫过的线段做 intersect_ray
+        ↓ 命中
+HitResolver.resolve()      ← 用落点实时速度算动能
+        ↓ DamageInfo
+HealthSystem.apply_damage()
+```
+
+关键点在最后一步之前：动能用的是**落点速度**而非枪口初速。速度已经过全程阻力与重力衰减，因此"远距离伤害衰减"不需要任何距离衰减曲线。
+
+## 为什么不是每帧一个点
+
+900 m/s 的弹头在 60 Hz 下每帧前进 15 米。如果只在每帧的落点做点检测，中间这 15 米里的任何目标都会被穿过去。系统改为**分段射线**：每帧对"上一帧位置 → 本帧位置"这条线段做 `intersect_ray`，速度再高也不会漏检。
+
+`max_step_distance_m`（默认 2.0）进一步把单帧位移切成子步，`max_time_step_s`（1/240）限制单步时长——高速弹在薄目标上的命中判定因此保持稳定。
+
+## BallisticEnvironmentConfig
+
+| 分组 | 字段 | 默认 | 说明 |
+|---|---|---|---|
+| Atmosphere | `gravity_mps2` | 9.80665 | 重力加速度 |
+| Atmosphere | `air_density_kg_m3` | 1.225 | 空气密度，影响阻力 |
+| Atmosphere | `temperature_c` / `pressure_pa` | 15.0 / 101325 | 大气状态 |
+| Atmosphere | `wind_velocity_mps` | ZERO | 风矢量，直接叠加到弹道 |
+| Simulation limits | `max_range_m` | 2000.0 | 超程移除 |
+| Simulation limits | `max_flight_time_s` | 8.0 | 超时移除（防泄漏兜底） |
+| Simulation limits | `minimum_effective_speed_mps` | 40.0 | 低于此速视为失能弹头 |
+| Simulation limits | `max_time_step_s` / `max_step_distance_m` | 1/240 / 2.0 | 子步切分精度 |
+| Simulation limits | `max_penetrations_per_frame` | 4 | 单帧穿透次数上限 |
+
+`minimum_effective_speed_mps` 的意义不是性能，而是物理：低于 40 m/s 的弹头动能已不足以形成有效伤口，继续模拟只会产生"擦伤式"的无意义命中。
+
+## BallisticSurfaceConfig
+
+穿透与跳弹按材质定义，不按"墙/木头"这类硬编码类型：
+
+| 字段 | 默认 | 说明 |
+|---|---|---|
+| `material_name` | `hard_surface` | 材质标识 |
+| `penetrable` | false | 是否可被穿透 |
+| `thickness_m` | 0.1 | 厚度，参与穿透判定 |
+| `hardness` | 1.0 | 硬度系数 |
+| `energy_loss_factor` | 0.45 | 穿透后保留的动能比例损失 |
+| `penetration_resistance_j` | 1000.0 | 穿透所需最低动能（焦耳） |
+| `ricochet_angle_deg` | 15.0 | 小于此入射角时发生跳弹 |
+| `ricochet_energy_retention` | 0.65 | 跳弹后保留的动能比例 |
+
+因为阈值是**焦耳**而非"能/不能穿"的布尔，同一堵墙对手枪弹和步枪弹的表现自然不同，且穿透后的剩余动能继续参与后续命中的伤害计算。
+
+## 命中解析的两条路径
+
+`HitResolver` 依据被命中的碰撞体类型分流：
+
+- **存活目标** — 命中 `BodyHitbox`（Area3D，layer 2），直接读 `get_body_part_id()`
+- **尸体** — 命中布娃娃的 `PhysicalBone3D`，按骨骼名经 `BONE_PART_MAP` 映射部位
+
+两条路径最终产出同一个 `DamageInfo`，交给同一个 `HealthSystem.apply_damage()`。存活目标还会附带伤道信息（`anchor_bone` / `local_entry` / `local_direction`），供 [医疗系统](../player/MedicalSystem.md) 的解剖求解判定是否伤及器官、骨骼或大血管。
+
+## hitscan 回退
+
+`WeaponConfig.use_ballistic_simulation` 关闭时走 `projectile.gd` 的瞬时射线：无飞行时间、无下坠、按枪口初速计算动能。保留这条路径是为了 A/B 对比调参，以及给不需要弹道细节的武器留出口。
+
+## 射手自身排除
+
+弹丸射线携带射手的碰撞体 RID 排除表（`BasePlayer` 胶囊 + 全部 `BodyHitbox`）。摄像机位于射手头部 hitbox 内部，若不排除，从摄像机出发的射线会立刻命中射手自己的头。
+
+## 测试
+
+`tests/ballistic_physics_check.gd` 与 `tests/environment_impact_parse_check.gd` 覆盖弹道积分与表面配置解析。

--- a/docs/encounter/EncounterSystemOverview.md
+++ b/docs/encounter/EncounterSystemOverview.md
@@ -1,0 +1,93 @@
+# 遭遇战系统概览
+
+## 核心理念
+
+**规则是纯数据对象，场景只是它的显示层。** `EncounterRules` 是 `RefCounted`，不继承 `Node`、不进场景树、不认识任何 3D 节点。它只接收"谁在目标区内、现在几点"，输出状态与信号。`EncounterController` 才是场景里的那一层，负责把 `EncounterZone` 的进出事件喂给规则，并把规则发出的信号转给 HUD 和 AI。
+
+这样拆的直接收益：对局规则可以在无场景的测试里逐帧推进（见 `tests/encounter_rules_check.gd`），不需要实例化地图、玩家或 AI。
+
+**撤离不是终点，是决策点。** 参照《Conflict》开发大纲，任务完成后对局不立即结束——撤离窗口开启，玩家可以选择继续作战或撤离，这两种选择通向不同的结算结果。
+
+## 文件结构
+
+```
+classes/encounter/
+├── encounter_rules.gd         ← 纯规则状态机（RefCounted，无场景依赖）
+├── encounter_controller.gd    ← 场景层：接线 Zone / HUD / AI
+├── encounter_config.gd        ← 对局参数资源
+├── encounter_zone.gd          ← 目标点/撤离点区域（Area3D）
+├── encounter_ai_director.gd   ← 把对局状态写进 AI 黑板
+├── encounter_hud.gd           ← 对局状态显示
+├── encounter_prototype.gd     ← 原型场景装配
+└── medical_treatment_component.gd  ← 队友互救（拖曳/止血/唤醒）
+```
+
+## 对局状态机
+
+`EncounterRules.MatchState`：
+
+```text
+DEPLOYMENT ──→ ACTIVE ──→ OBJECTIVE_SECURED ──→ EXTRACTION_OPEN
+                  │                                    │
+                  │                                    ├──→ MATCH_SUCCESS
+                  ├──→ MATCH_FAILED                    └──→ MATCH_PARTIAL_SUCCESS
+                  │    （全队阵亡）
+                  └──→ MATCH_FAILED
+                       （超时且无人撤离）
+```
+
+| 状态 | 含义 |
+|---|---|
+| `DEPLOYMENT` | 部署准备阶段，`deployment_duration` 为 0 时直接跳过 |
+| `ACTIVE` | 对局进行中，计时开始 |
+| `OBJECTIVE_SECURED` | 目标点控制满 `objective_control_duration` |
+| `EXTRACTION_OPEN` | 撤离窗口开启 |
+| `MATCH_SUCCESS` | 任务完成 + 有人撤离 |
+| `MATCH_PARTIAL_SUCCESS` | 时间耗尽 + 有人撤离 |
+| `MATCH_FAILED` | 全队阵亡，或超时且无人撤离 |
+
+## 目标点控制
+
+`ObjectiveState` 独立于对局状态：`UNCONTROLLED` / `CONTESTED` / `RU_CONTROLLED` / `UA_CONTROLLED` / `SECURED`。
+
+区内同时存在双方成员时进入 `CONTESTED`，控制进度停滞而非清零。只有单方独占才继续累计，累计满 `objective_control_duration`（默认 90s）后转 `SECURED`。`objective_progress_changed(progress, control_faction, objective_state)` 每次变化时发出，HUD 直接消费这一个信号即可，无需自行轮询。
+
+## EncounterConfig
+
+| 分组 | 字段 | 默认 | 说明 |
+|---|---|---|---|
+| Match | `match_duration` | 600.0 | 对局总时长（秒），超时强制结算 |
+| Match | `deployment_duration` | 0.0 | 部署阶段时长；0 = 跳过 |
+| Match | `objective_control_duration` | 90.0 | 目标点控制满多久算 `SECURED` |
+| Match | `extraction_duration` | 20.0 | 在撤离区停留多久算撤离成功 |
+| Match | `player_faction` | 0 | 玩家所属阵营 |
+| Zones | `objective_radius` | 8.0 | 目标区半径 |
+| Zones | `extraction_radius` | 5.0 | 撤离区半径 |
+| Zones | `max_medical_distance` | 2.5 | 队友互救的最大距离 |
+| Zones | `player_spawn_position` / `player_spawn_yaw_degrees` | — | 玩家出生点与朝向 |
+
+区域半径同时写入 `EncounterZone.set_radius()`，`Area3D` 的碰撞形状据此重建——半径只有一个真值来源，不会出现配置与碰撞体不一致。
+
+## 与 AI 系统的接线
+
+`EncounterAIDirector` 是遭遇战与 [AI 系统](../ai/AISystemOverview.md) 之间唯一的桥：
+
+```text
+EncounterRules（对局状态）
+        ↓ 信号
+EncounterAIDirector
+        ↓ 写入
+AIBlackboard.objective_position / extraction_position / retreat_order
+        ↑ 读取
+AIPlayerBrain
+```
+
+方向是单向的。AI 从不回写对局状态；它对目标点的"贡献"只体现为它站在 `EncounterZone` 里，由 `EncounterController` 统一上报。这避免了"AI 自己宣布占领了目标点"这类越权。
+
+## 队友互救
+
+`MedicalTreatmentComponent` 实现开发大纲中"仅队友可执行"的那部分急救动作。距离由 `max_medical_distance`（2.5m）限制，治疗过程通过 `BasePlayer.CONTROL_LOCK_MEDICAL` 持有控制锁——施救者在动作期间让出移动控制权，与暂停菜单、自由视角使用同一套 `PlayerControlState` 仲裁，不会互相覆盖。
+
+## 测试
+
+`tests/encounter_rules_check.gd` 直接实例化 `EncounterRules` 并手动推进时间，验证状态迁移与结算分支。因为规则层没有场景依赖，这些断言不需要跑起整张地图。


### PR DESCRIPTION
## 背景

AI、遭遇战、弹道三个子系统此前**完全没有文档**——加起来 24 个脚本、约 4000 行，而其它主要系统至少都有一份模块页。这个 PR 补上这三份概览。

与其为 60 多个未文档化的脚本各写一页薄壳，这里沿用 `AttachmentSystemOverview.md` 已有的"子系统概览"粒度：讲清边界、数据流与设计取舍，而不是复述 API。

## 新增

**`docs/ai/AISystemOverview.md`**
- 四层职责划分（Manager / SquadCommander / Blackboard / Brain），只向下调用、向上发布
- 15 个状态按用途分组；`DOWNED` / `DEAD` 是 `HealthSystem` 的投影而非决策产物
- 三重感知过滤（距离 → 视野角 → 视线）与 `reaction_time` / `target_memory_time`
- `AIProfile` 参数表
- 为什么 AI 复用 `BasePlayer` 而不是自带移动与伤害通路

**`docs/encounter/EncounterSystemOverview.md`**
- 对局状态机，含开发大纲里"撤离是决策点而非终点"的分支
- 目标点控制：`CONTESTED` 时进度**停滞而非清零**
- `EncounterConfig` 完整字段表
- `EncounterAIDirector` 作为单向桥，AI 从不回写对局状态

**`docs/combat/BallisticsSystemOverview.md`**
- 没有"伤害值"字段：伤害由落点动能现算
- 弹丸是数据不是节点
- 为什么用分段射线而不是每帧一个点（900 m/s 在 60 Hz 下每帧 15 米）
- 环境与表面配置表；穿透阈值是焦耳而非布尔
- `HitResolver` 存活 / 尸体两条路径

**`docs/README.md`** — 模块索引补三节及对应类表。

## 说明

- 纯文档，无代码改动。
- 分支基于上游 `feat/game-logic-and-menu` 最新提交，因此本 PR 顺带把 fork 的同名分支同步到上游 #42 合并后的状态。
- 所有交叉链接已验证可解析。

## 仍未文档化

console system、radial menu、title / loading screen、姿态与卧倒、以及医疗子资源（`AnatomyConfig` / `AnatomySolver` / `Wound`）。可按需继续。
