### PR TITLE
Fix AI procedural aim and hand/foot IK regressions

### DIFF
--- a/classes/bot/ai_player_brain.gd
+++ b/classes/bot/ai_player_brain.gd
@@ -311,13 +311,12 @@ func _move_to(destination: Vector3, profile: AIProfile, delta: float) -> void:
 	var running := profile.run_to_objective and state in [State.MOVE_TO_OBJECTIVE, State.MOVE_UNDER_COVER, State.RETREAT]
 	var sprinting := profile.sprint_when_retreating and state == State.RETREAT
 	bot.set_ai_input(direction, running, sprinting)
-	_face(bot.global_position + direction)
+	# Navigation commands a level heading; terrain height must not pitch the weapon.
+	_face(bot.global_position + Vector3(direction.x, 0.0, direction.z))
 
 
 func _face(position: Vector3) -> void:
-	var flat := Vector3(position.x, bot.global_position.y, position.z)
-	if flat.distance_to(bot.global_position) > 0.05:
-		bot.look_at(flat, Vector3.UP)
+	bot.set_ai_aim_direction(position - bot.global_position)
 
 
 func _stop() -> void:
@@ -381,7 +380,10 @@ func _apply_aim_error(profile: AIProfile) -> void:
 		return
 	# The weapon remains authoritative for projectile creation and damage. This
 	# only changes the AIPlayer's commanded aim by a configurable small yaw error.
-	bot.rotate_y(deg_to_rad(randf_range(-profile.aim_error_degrees, profile.aim_error_degrees)))
+	var pitch := bot.camera_controller.get_vertical_angle()
+	var direction := -bot.global_basis.z * cos(pitch) + Vector3.UP * sin(pitch)
+	var yaw_error := deg_to_rad(randf_range(-profile.aim_error_degrees, profile.aim_error_degrees))
+	bot.set_ai_aim_direction(direction.rotated(Vector3.UP, yaw_error))
 
 
 func _get_known_actors() -> Array[BasePlayer]:

--- a/classes/player/base_player.gd
+++ b/classes/player/base_player.gd
@@ -318,6 +318,7 @@ func _create_subsystem(subsystem: Node, node_name: String) -> Node: # 创建子�
 func _connect_signals() -> void:
 	model_manager.model_loaded.connect(_on_model_loaded)
 	weapon_manager.weapon_changed.connect(_on_weapon_changed)
+	weapon_manager.aiming_changed.connect(hand_ik_controller.set_ads_state)
 	weapon_manager.weapon_stats_changed.connect(_sync_weapon_weight_to_stamina)
 	# 连接姿态变化信号
 	stance_controller.stance_changed.connect(_on_stance_changed)
@@ -512,7 +513,7 @@ func _process(delta: float) -> void:
 	spine_aim_controller.process_aim(delta, procedural_animation_active and not prone)
 	hand_ik_controller.set_prone_state(prone)
 	hand_ik_controller.process_ik(delta, procedural_animation_active)
-	foot_ik_controller.process_ik(delta, procedural_animation_active and not prone)
+	foot_ik_controller.set_active(procedural_animation_active and not prone, delta if procedural_animation_active else 0.0)
 
 
 func _sync_prone_mesh_floor_offset() -> void:
@@ -838,6 +839,9 @@ func _activate_ragdoll(
 		camera_controller.clear_pain_impulse()
 		camera_controller.set_ragdoll_camera_shake(false)
 	is_ragdolled = true
+	spine_aim_controller.process_aim(0.0, false)
+	hand_ik_controller.process_ik(0.0, false)
+	foot_ik_controller.set_active(false)
 	velocity = Vector3.ZERO
 	_set_collision_enabled(false)
 	# 轻微上移玩家原点，给物理骨骼初始位置留出与地面的间隙，
@@ -956,6 +960,21 @@ func set_ai_input(world_direction: Vector3, running: bool = false, sprinting: bo
 func clear_ai_input() -> void:
 	if movement_controller:
 		movement_controller.clear_ai_input()
+
+
+## AI owns body yaw; elevation is consumed by the same spine aim as local view input.
+func set_ai_aim_direction(world_direction: Vector3) -> bool:
+	if not is_ai_player or not is_alive or is_ragdolled or not camera_controller:
+		return false
+	if not world_direction.is_finite() or world_direction.is_zero_approx():
+		return false
+	var direction := world_direction.normalized()
+	var horizontal := Vector3(direction.x, 0.0, direction.z)
+	if horizontal.length_squared() > 0.000001:
+		look_at(global_position + horizontal, Vector3.UP)
+	var pitch := atan2(direction.y, horizontal.length())
+	camera_controller.set_ai_view_angles(rotation.y, pitch)
+	return true
 
 
 func set_ai_fire_input(pressed: bool) -> void:

--- a/classes/player/foot_ik_controller.gd
+++ b/classes/player/foot_ik_controller.gd
@@ -1,155 +1,125 @@
 class_name FootIKController
 extends Node
 
-
 var _skeleton: Skeleton3D
 var _model_manager: PlayerModelManager
-var _config: ModelLookupConfig
-var _player: CharacterBody3D  # 用于排除自身碰撞
-
+var _player: CharacterBody3D
 var _left_ik: TwoBoneIK3D
 var _right_ik: TwoBoneIK3D
 var _left_target: Marker3D
 var _right_target: Marker3D
-var _left_pole: Marker3D
-var _right_pole: Marker3D
-var _left_ready: bool = false
-var _right_ready: bool = false
-
-var _left_blend: float = 0.0
-var _right_blend: float = 0.0
-
+var _left_blend := 0.0
+var _right_blend := 0.0
+var _left_foot_idx := -1
+var _right_foot_idx := -1
 var _ankle_modifier: FootAnkleModifier
+var _pose_modifier: FootPoseModifier
+var _active := true
+var _left_hit := {"colliding": false, "point": Vector3.ZERO, "normal": Vector3.UP}
+var _right_hit := {"colliding": false, "point": Vector3.ZERO, "normal": Vector3.UP}
 
-var _left_foot_idx: int = -1
-var _right_foot_idx: int = -1
-var _left_hip_idx: int = -1
-var _left_knee_idx: int = -1
-var _right_hip_idx: int = -1
-var _right_knee_idx: int = -1
-
-const BLEND_SPEED       := 8.0
-const RAY_ABOVE         := 0.3    # 射线起点在脚骨上方多少米
-const RAY_BELOW         := 0.4    # 射线向下扫多少米
-const ANKLE_OFFSET      := 0.05   # 脚踝关节到脚底的距离（米），防止脚陷地/悬空，按实际模型微调
-const ANKLE_BONE_LEFT   := "mixamorig_LeftFoot"
-const ANKLE_BONE_RIGHT  := "mixamorig_RightFoot"
-const HIP_BONE_LEFT     := "mixamorig_LeftUpLeg"
-const KNEE_BONE_LEFT    := "mixamorig_LeftLeg"
-const HIP_BONE_RIGHT    := "mixamorig_RightUpLeg"
-const KNEE_BONE_RIGHT   := "mixamorig_RightLeg"
-
-var _diag_timer: int = 0
-const DIAG_INTERVAL := 180
+const BLEND_SPEED := 8.0
+const RAY_ABOVE := 0.3
+const RAY_BELOW := 0.4
+const ANKLE_OFFSET := 0.05
+const ANKLE_BONE_LEFT := "mixamorig_LeftFoot"
+const ANKLE_BONE_RIGHT := "mixamorig_RightFoot"
+# Lift is measured against the rig's rest feet, not the ground beneath a step.
+const PLANT_LIFT_START := 0.035
+const PLANT_LIFT_END := 0.12
 
 
-func initialize(model_manager: PlayerModelManager, config: ModelLookupConfig) -> void:
+func initialize(model_manager: PlayerModelManager, _config: ModelLookupConfig) -> void:
+	if is_instance_valid(_model_manager):
+		if _model_manager.model_loaded.is_connected(_on_model_loaded):
+			_model_manager.model_loaded.disconnect(_on_model_loaded)
+		if _model_manager.model_unloaded.is_connected(clear):
+			_model_manager.model_unloaded.disconnect(clear)
+	clear()
 	_model_manager = model_manager
-	_config = config
-	_skeleton = model_manager.skeleton
-	# 向上找到 CharacterBody3D，用于射线排除自身
-	var n: Node = model_manager
-	while n:
-		if n is CharacterBody3D:
-			_player = n as CharacterBody3D
-			break
-		n = n.get_parent()
+	var node: Node = model_manager
+	while node and not node is CharacterBody3D:
+		node = node.get_parent()
+	_player = node as CharacterBody3D
 	_model_manager.model_loaded.connect(_on_model_loaded)
+	_model_manager.model_unloaded.connect(clear)
+	if is_instance_valid(model_manager.skeleton):
+		_on_model_loaded(model_manager.model_node)
+
+
+func clear() -> void:
+	set_active(false)
+	for modifier in [_pose_modifier, _ankle_modifier]:
+		if is_instance_valid(modifier):
+			modifier.active = false
+			if modifier.get_parent():
+				modifier.get_parent().remove_child(modifier)
+			modifier.queue_free()
+	_pose_modifier = null
+	_ankle_modifier = null
+	_skeleton = null
+	_left_ik = null
+	_right_ik = null
+	_left_target = null
+	_right_target = null
+	_left_foot_idx = -1
+	_right_foot_idx = -1
+	_left_hit = {"colliding": false, "point": Vector3.ZERO, "normal": Vector3.UP}
+	_right_hit = _left_hit.duplicate()
 
 
 func _on_model_loaded(_model: Node3D) -> void:
+	clear()
 	_skeleton = _model_manager.skeleton
 	_setup()
+	set_active(true)
 
 
 func _setup() -> void:
-	if not _skeleton:
+	if not is_instance_valid(_skeleton):
 		return
-
-	_left_ik      = _skeleton.get_node_or_null("LeftFootIK")      as TwoBoneIK3D
-	_right_ik     = _skeleton.get_node_or_null("RightFootIK")     as TwoBoneIK3D
-	_left_target  = _skeleton.get_node_or_null("LeftFootTarget")  as Marker3D
+	_left_ik = _skeleton.get_node_or_null("LeftFootIK") as TwoBoneIK3D
+	_right_ik = _skeleton.get_node_or_null("RightFootIK") as TwoBoneIK3D
+	_left_target = _skeleton.get_node_or_null("LeftFootTarget") as Marker3D
 	_right_target = _skeleton.get_node_or_null("RightFootTarget") as Marker3D
-	_left_pole    = _left_ik.get_node_or_null("LeftKneePole") as Marker3D if _left_ik else null
-	_right_pole   = _right_ik.get_node_or_null("RightKneePole") as Marker3D if _right_ik else null
-
-	_left_hip_idx   = _skeleton.find_bone(HIP_BONE_LEFT)
-	_left_knee_idx  = _skeleton.find_bone(KNEE_BONE_LEFT)
-	_left_foot_idx  = _skeleton.find_bone(ANKLE_BONE_LEFT)
-	_right_hip_idx  = _skeleton.find_bone(HIP_BONE_RIGHT)
-	_right_knee_idx = _skeleton.find_bone(KNEE_BONE_RIGHT)
+	_left_foot_idx = _skeleton.find_bone(ANKLE_BONE_LEFT)
 	_right_foot_idx = _skeleton.find_bone(ANKLE_BONE_RIGHT)
+	_bind_leg(_left_ik, _left_target, _left_foot_idx)
+	_bind_leg(_right_ik, _right_target, _right_foot_idx)
+	if not _valid_leg(_left_ik, _left_target, _left_foot_idx) and not _valid_leg(_right_ik, _right_target, _right_foot_idx):
+		GlobalLogger.warn("FootIK", "Model has no complete foot IK chain; ground adaptation disabled.")
+		return
+	_pose_modifier = FootPoseModifier.new()
+	_pose_modifier.name = "FootPoseSync"
+	_pose_modifier.controller = self
+	_skeleton.add_child(_pose_modifier)
+	# Sample the animated legs before either leg IK can feed its result back.
+	var first_index := _skeleton.get_child_count() - 1
+	for solver in [_left_ik, _right_ik]:
+		if is_instance_valid(solver):
+			first_index = mini(first_index, solver.get_index())
+	_skeleton.move_child(_pose_modifier, first_index)
+	_ankle_modifier = FootAnkleModifier.new()
+	_ankle_modifier.name = "FootAnkleModifier"
+	_skeleton.add_child(_ankle_modifier)
+	_ankle_modifier.setup(_skeleton, self)
 
-	_left_ready = _configure_leg(
-		"left", _left_ik, _left_target, _left_pole,
-		_left_hip_idx, _left_knee_idx, _left_foot_idx,
-		HIP_BONE_LEFT, KNEE_BONE_LEFT, ANKLE_BONE_LEFT
-	)
-	_right_ready = _configure_leg(
-		"right", _right_ik, _right_target, _right_pole,
-		_right_hip_idx, _right_knee_idx, _right_foot_idx,
-		HIP_BONE_RIGHT, KNEE_BONE_RIGHT, ANKLE_BONE_RIGHT
-	)
 
-	_setup_ankle_modifier()
-	_apply_blends()
-
-	GlobalLogger.info("FootIK", "脚部 IK 初始化完成  left_ready=%s  right_ready=%s" % [
-		str(_left_ready), str(_right_ready)])
-
-
-func _configure_leg(
-	side: String,
-	ik: TwoBoneIK3D,
-	target: Marker3D,
-	pole: Marker3D,
-	hip_idx: int,
-	knee_idx: int,
-	foot_idx: int,
-	hip_name: String,
-	knee_name: String,
-	foot_name: String
-) -> bool:
-	if not _is_leg_complete(ik, target, pole, hip_idx, knee_idx, foot_idx):
-		if ik:
-			ik.influence = 0.0
-		GlobalLogger.warn(
-			"FootIK",
-			"%s leg IK 配置不完整；该侧已安全禁用（需要 IK、target、pole 和连续的三段骨骼）。" % side
-		)
+func _valid_leg(solver: TwoBoneIK3D, target: Marker3D, bone_idx: int) -> bool:
+	if not is_instance_valid(solver) or solver.setting_count < 1 or not is_instance_valid(target) or bone_idx < 0:
 		return false
-
-	# Keep scene-authored nodes, but refresh every reference against the currently
-	# loaded skeleton. This also makes model hot-reload safe.
-	ik.set("setting_count", 1)
-	ik.set("settings/0/target_node", ik.get_path_to(target))
-	ik.set("settings/0/pole_node", ik.get_path_to(pole))
-	ik.set("settings/0/root_bone_name", hip_name)
-	ik.set("settings/0/root_bone", hip_idx)
-	ik.set("settings/0/middle_bone_name", knee_name)
-	ik.set("settings/0/middle_bone", knee_idx)
-	ik.set("settings/0/end_bone_name", foot_name)
-	ik.set("settings/0/end_bone", foot_idx)
-	ik.influence = 0.0
-	target.global_position = _bone_world_position(foot_idx)
-	_update_leg_pole(pole, hip_idx, knee_idx, foot_idx)
-	return true
+	var root := solver.get_root_bone(0)
+	var middle := solver.get_middle_bone(0)
+	return root >= 0 and middle >= 0 and solver.get_end_bone(0) == bone_idx \
+		and _skeleton.get_bone_parent(middle) == root and _skeleton.get_bone_parent(bone_idx) == middle \
+		and solver.get_node_or_null(solver.get_pole_node(0)) is Marker3D
 
 
-func _is_leg_complete(
-	ik: TwoBoneIK3D,
-	target: Marker3D,
-	pole: Marker3D,
-	hip_idx: int,
-	knee_idx: int,
-	foot_idx: int
-) -> bool:
-	if not ik or not target or not pole or not is_instance_valid(_skeleton):
-		return false
-	if hip_idx < 0 or knee_idx < 0 or foot_idx < 0:
-		return false
-	return _skeleton.get_bone_parent(knee_idx) == hip_idx \
-		and _skeleton.get_bone_parent(foot_idx) == knee_idx
+func _bind_leg(solver: TwoBoneIK3D, target: Marker3D, bone_idx: int) -> void:
+	if is_instance_valid(solver):
+		solver.influence = 0.0
+	if _valid_leg(solver, target, bone_idx):
+		solver.set_target_node(0, solver.get_path_to(target))
 
 
 func _bone_world_position(bone_idx: int) -> Vector3:
@@ -174,172 +144,135 @@ func _update_leg_pole(pole: Marker3D, hip_idx: int, knee_idx: int, foot_idx: int
 	pole.global_position = knee + bend.normalized() * pole_distance
 
 
-func _setup_ankle_modifier() -> void:
-	_ankle_modifier = _skeleton.get_node_or_null("FootAnkleModifier") as FootAnkleModifier
-	if not _ankle_modifier:
-		_ankle_modifier = FootAnkleModifier.new()
-		_ankle_modifier.name = "FootAnkleModifier"
-		_skeleton.add_child(_ankle_modifier)
-	_ankle_modifier.setup(_skeleton, self)
+func set_active(enabled: bool, fade_delta: float = 0.0) -> void:
+	_active = enabled
+	if not enabled:
+		# Prone transitions fade; death/unload callers use the immediate default.
+		_left_blend = move_toward(_left_blend, 0.0, BLEND_SPEED * fade_delta) if fade_delta > 0.0 else 0.0
+		_right_blend = move_toward(_right_blend, 0.0, BLEND_SPEED * fade_delta) if fade_delta > 0.0 else 0.0
+		if is_instance_valid(_left_ik):
+			_left_ik.influence = _left_blend
+		if is_instance_valid(_right_ik):
+			_right_ik.influence = _right_blend
+		if is_instance_valid(_ankle_modifier):
+			_ankle_modifier.left_blend = _left_blend
+			_ankle_modifier.right_blend = _right_blend
+	if is_instance_valid(_pose_modifier):
+		_pose_modifier.active = enabled
+	if is_instance_valid(_ankle_modifier):
+		_ankle_modifier.active = enabled or _left_blend > 0.0 or _right_blend > 0.0
 
 
-func process_ik(delta: float, active: bool = true) -> void:
-	if not is_instance_valid(_skeleton):
+func _physics_process(_delta: float) -> void:
+	if not _active or not is_instance_valid(_skeleton):
 		return
-	if not active:
-		# Prone/roll clips author the legs, but cutting a standing solver in one
-		# frame causes a visible pop. Fade the procedural layer out instead.
-		_left_blend = move_toward(_left_blend, 0.0, BLEND_SPEED * delta)
-		_right_blend = move_toward(_right_blend, 0.0, BLEND_SPEED * delta)
-		_apply_blends()
+	# Physics queries stay in the physics tick. Pose targets and plant weights
+	# use the current animation later, inside FootPoseModifier.
+	_left_hit = _raycast_foot(_left_foot_idx)
+	_right_hit = _raycast_foot(_right_foot_idx)
+
+
+func process_ik(delta: float, enabled: bool = true) -> void:
+	set_active(enabled)
+	if not enabled or not is_instance_valid(_skeleton):
 		return
-	if not _left_ready and not _right_ready:
-		_apply_blends()
-		return
-
-	if _left_ready:
-		_update_leg_pole(_left_pole, _left_hip_idx, _left_knee_idx, _left_foot_idx)
-	if _right_ready:
-		_update_leg_pole(_right_pole, _right_hip_idx, _right_knee_idx, _right_foot_idx)
-
-	var left_hit := _raycast_foot(_left_foot_idx) if _left_ready else _empty_hit()
-	var right_hit := _raycast_foot(_right_foot_idx) if _right_ready else _empty_hit()
-
-	var on_ground := _player != null and _player.is_on_floor()
-
-	var left_target_blend := 1.0 if (_left_ready and left_hit.colliding and on_ground) else 0.0
-	var right_target_blend := 1.0 if (_right_ready and right_hit.colliding and on_ground) else 0.0
-
-	_left_blend  = move_toward(_left_blend,  left_target_blend,  BLEND_SPEED * delta)
-	_right_blend = move_toward(_right_blend, right_target_blend, BLEND_SPEED * delta)
-
-	# target 位置 = 地面碰撞点 + 脚踝偏移，防止脚踝关节沉入地面
-	if _left_ready and left_hit.colliding:
-		_left_target.global_position = left_hit.point + Vector3.UP * ANKLE_OFFSET
-	if _right_ready and right_hit.colliding:
-		_right_target.global_position = right_hit.point + Vector3.UP * ANKLE_OFFSET
-
-	if _ankle_modifier:
-		_ankle_modifier.left_normal  = left_hit.normal  if left_hit.colliding  else Vector3.UP
-		_ankle_modifier.right_normal = right_hit.normal if right_hit.colliding else Vector3.UP
-	_apply_blends()
-
-	_diag_timer += 1
-	if _diag_timer >= DIAG_INTERVAL:
-		_diag_timer = 0
+	var on_ground := is_instance_valid(_player) and _player.is_on_floor()
+	_left_blend = _update_leg(_left_ik, _left_target, _left_foot_idx, _left_hit, _left_blend, delta, on_ground)
+	_right_blend = _update_leg(_right_ik, _right_target, _right_foot_idx, _right_hit, _right_blend, delta, on_ground)
+	if is_instance_valid(_ankle_modifier):
+		_ankle_modifier.left_normal = _left_hit.normal
+		_ankle_modifier.right_normal = _right_hit.normal
+		_ankle_modifier.left_blend = _left_blend
+		_ankle_modifier.right_blend = _right_blend
 
 
-func _apply_blends() -> void:
-	if _left_ik:
-		_left_ik.influence = _left_blend if _left_ready else 0.0
-	if _right_ik:
-		_right_ik.influence = _right_blend if _right_ready else 0.0
-	if _ankle_modifier:
-		_ankle_modifier.left_blend = _left_blend if _left_ready else 0.0
-		_ankle_modifier.right_blend = _right_blend if _right_ready else 0.0
+func _plant_weight(bone_idx: int) -> float:
+	var animated := _skeleton.global_transform * _skeleton.get_bone_global_pose(bone_idx).origin
+	var resting := _skeleton.global_transform * _skeleton.get_bone_global_rest(bone_idx).origin
+	var lift := maxf(animated.y - resting.y, 0.0)
+	return 1.0 - smoothstep(PLANT_LIFT_START, PLANT_LIFT_END, lift)
 
 
-func _empty_hit() -> Dictionary:
-	return {"colliding": false, "point": Vector3.ZERO, "normal": Vector3.UP}
+func _update_leg(solver: TwoBoneIK3D, target: Marker3D, bone_idx: int, hit: Dictionary, blend: float, delta: float, on_ground: bool) -> float:
+	if not _valid_leg(solver, target, bone_idx):
+		if is_instance_valid(solver):
+			solver.influence = 0.0
+		return 0.0
+	var knee := _skeleton.get_bone_parent(bone_idx)
+	_update_leg_pole(solver.get_node(solver.get_pole_node(0)) as Marker3D, _skeleton.get_bone_parent(knee), knee, bone_idx)
+	var plant := _plant_weight(bone_idx)
+	var weight := plant if on_ground and hit.colliding else 0.0
+	# Fade contact acquisition, but never let last frame's weight pin a lifted foot.
+	blend = minf(move_toward(blend, weight, BLEND_SPEED * maxf(delta, 0.0)), plant)
+	var animated_world := _skeleton.global_transform * _skeleton.get_bone_global_pose(bone_idx).origin
+	if hit.colliding and on_ground:
+		# Project this frame's foot onto the cached contact plane, keeping animation X/Z.
+		var normal: Vector3 = hit.normal
+		if normal.y > 0.1:
+			var ground_y: float = hit.point.y - (normal.x * (animated_world.x - hit.point.x) + normal.z * (animated_world.z - hit.point.z)) / normal.y
+			target.global_position = Vector3(animated_world.x, ground_y + ANKLE_OFFSET, animated_world.z)
+		else:
+			blend = 0.0
+	else:
+		target.global_position = animated_world
+	solver.influence = blend
+	return blend
 
 
-# 从脚骨骼世界位置上方向下投射射线，不依赖 BoneAttachment3D
 func _raycast_foot(bone_idx: int) -> Dictionary:
 	var result := {"colliding": false, "point": Vector3.ZERO, "normal": Vector3.UP}
-	if bone_idx == -1 or not is_instance_valid(_skeleton):
+	if bone_idx < 0 or not is_instance_valid(_skeleton):
 		return result
-
-	# 脚骨骼当前世界位置
-	var foot_world: Vector3 = (_skeleton.global_transform * _skeleton.get_bone_global_pose(bone_idx)).origin
-	var ray_from := foot_world + Vector3.UP * RAY_ABOVE
-	var ray_to   := foot_world + Vector3.DOWN * RAY_BELOW
-
-	var query := PhysicsRayQueryParameters3D.create(ray_from, ray_to)
-	query.collision_mask = PhysicsLayers.WORLD
-	if _player:
+	var foot_world := (_skeleton.global_transform * _skeleton.get_bone_global_pose(bone_idx)).origin
+	var query := PhysicsRayQueryParameters3D.create(foot_world + Vector3.UP * RAY_ABOVE, foot_world + Vector3.DOWN * RAY_BELOW, PhysicsLayers.WORLD)
+	if is_instance_valid(_player):
 		query.exclude = [_player.get_rid()]
-
-	var space := _skeleton.get_world_3d().direct_space_state
-	if not space:
-		return result
-
-	var hit := space.intersect_ray(query)
+	var hit := _skeleton.get_world_3d().direct_space_state.intersect_ray(query)
 	if not hit.is_empty():
 		result.colliding = true
-		result.point     = hit.position
-		result.normal    = hit.normal
+		result.point = hit.position
+		result.normal = hit.normal
 	return result
 
 
-# ─────────────────────────────────────────────────────────────
-# 脚踝法线对齐修改器
-# ─────────────────────────────────────────────────────────────
+class FootPoseModifier extends SkeletonModifier3D:
+	var controller: FootIKController
+
+	func _process_modification_with_delta(delta: float) -> void:
+		if is_instance_valid(controller) and controller._active:
+			controller.process_ik(delta)
+
+
 class FootAnkleModifier extends SkeletonModifier3D:
-
-	var _skeleton: Skeleton3D
-	var _left_idx: int  = -1
-	var _right_idx: int = -1
-
-	var left_normal:  Vector3 = Vector3.UP
-	var right_normal: Vector3 = Vector3.UP
-	var left_blend:   float   = 0.0
-	var right_blend:  float   = 0.0
-
+	var _left_idx := -1
+	var _right_idx := -1
+	var left_normal := Vector3.UP
+	var right_normal := Vector3.UP
+	var left_blend := 0.0
+	var right_blend := 0.0
 
 	func setup(skeleton: Skeleton3D, _controller: FootIKController) -> void:
-		_skeleton = skeleton
-		_left_idx  = skeleton.find_bone(ANKLE_BONE_LEFT)
+		_left_idx = skeleton.find_bone(ANKLE_BONE_LEFT)
 		_right_idx = skeleton.find_bone(ANKLE_BONE_RIGHT)
 
-
 	func _process_modification() -> void:
-		if _left_idx != -1 and left_blend > 0.001:
+		if _left_idx >= 0 and left_blend > 0.001:
 			_apply_ankle_rotation(_left_idx, left_normal, left_blend)
-		if _right_idx != -1 and right_blend > 0.001:
+		if _right_idx >= 0 and right_blend > 0.001:
 			_apply_ankle_rotation(_right_idx, right_normal, right_blend)
-
 
 	func _apply_ankle_rotation(bone_idx: int, ground_normal: Vector3, blend: float) -> void:
 		var skel := get_skeleton()
 		if not skel:
 			return
-
-		# 计算世界 UP → 地面法线的旋转
-		var dot := Vector3.UP.dot(ground_normal)
-		if dot >= 0.9999:
-			return  # 平地，不旋转
-
-		var rot_axis := Vector3.UP.cross(ground_normal)
-		if rot_axis.length_squared() < 0.0001:
+		var axis := Vector3.UP.cross(ground_normal)
+		if axis.length_squared() < 0.0001:
 			return
-		var rot_angle := Vector3.UP.angle_to(ground_normal) * blend
-
-		# 限制最大旋转角（防止极端斜面扭断脚踝）
-		rot_angle = clampf(rot_angle, -deg_to_rad(25.0), deg_to_rad(25.0))
-
-		# set_bone_pose_rotation() expects a pose relative to the bone parent,
-		# not merely relative to Skeleton3D. Include the animated parent leg so
-		# slopes remain correct while the character turns or an IK solver bends it.
-		var world_rot   := Quaternion(rot_axis.normalized(), rot_angle)
-		var local_extra := _world_rotation_to_bone_parent_space(bone_idx, world_rot)
-
-		skel.set_bone_pose_rotation(
-			bone_idx,
-			(local_extra * skel.get_bone_pose_rotation(bone_idx)).normalized()
-		)
-
-
-	func _world_rotation_to_bone_parent_space(bone_idx: int, world_rotation: Quaternion) -> Quaternion:
-		var skel := get_skeleton()
-		if not skel or bone_idx < 0:
-			return Quaternion.IDENTITY
-		var parent_world_basis := skel.global_basis.orthonormalized()
+		var angle := minf(Vector3.UP.angle_to(ground_normal), deg_to_rad(25.0)) * blend
+		var world_extra := Quaternion(axis.normalized(), angle)
+		var parent_world := skel.global_basis.orthonormalized()
 		var parent_idx := skel.get_bone_parent(bone_idx)
 		if parent_idx >= 0:
-			parent_world_basis = (
-				skel.global_basis * skel.get_bone_global_pose(parent_idx).basis
-			).orthonormalized()
-		var parent_world_rotation := parent_world_basis.get_rotation_quaternion()
-		return (
-			parent_world_rotation.inverse() * world_rotation * parent_world_rotation
-		).normalized()
+			parent_world *= skel.get_bone_global_pose(parent_idx).basis.orthonormalized()
+		var local_extra := Quaternion(parent_world).inverse() * world_extra * Quaternion(parent_world)
+		skel.set_bone_pose_rotation(bone_idx, (local_extra * skel.get_bone_pose_rotation(bone_idx)).normalized())

--- a/classes/player/hand_ik_controller.gd
+++ b/classes/player/hand_ik_controller.gd
@@ -17,6 +17,9 @@ var _target_modifier: HandTargetModifier
 var _left_hand_grip: Node3D     # 武器上的 LeftHandGrip 掌心接触点
 var _left_hand_wrist_target: Node3D # 武器上的 LeftHandWristTarget 腕部目标
 var _using_wrist_target_fallback: bool = false
+var _wrist_modifier: HandWristModifier
+var _model_manager: PlayerModelManager
+var _owns_hand_target: bool = false
 var _current_weapon: BaseWeapon
 var _enabled: bool = false
 var _ik_weight: float = 1.0
@@ -38,19 +41,53 @@ var _current_weight: float = 0.0
 var _target_weight: float = 0.0
 
 
-func initialize(_model_manager: PlayerModelManager, _lookup: ModelLookupConfig) -> void:
-	pass
+func initialize(model_manager: PlayerModelManager, _lookup: ModelLookupConfig) -> void:
+	if is_instance_valid(_model_manager) and _model_manager.model_unloaded.is_connected(clear):
+		_model_manager.model_unloaded.disconnect(clear)
+	_model_manager = model_manager
+	if is_instance_valid(_model_manager):
+		_model_manager.model_unloaded.connect(clear)
+
+
+## Release old modifiers before accepting a replacement model, including failed loads.
+func clear() -> void:
+	_disconnect_weapon_attachments()
+	if is_instance_valid(_ik_node):
+		_ik_node.influence = 0.0
+	for modifier in [_target_modifier, _wrist_modifier]:
+		if is_instance_valid(modifier):
+			modifier.active = false
+			if modifier.get_parent():
+				modifier.get_parent().remove_child(modifier)
+			modifier.queue_free()
+	if _owns_hand_target and is_instance_valid(_hand_target):
+		if _hand_target.get_parent():
+			_hand_target.get_parent().remove_child(_hand_target)
+		_hand_target.queue_free()
+	_ik_node = null
+	_target_modifier = null
+	_wrist_modifier = null
+	_hand_target = null
+	_owns_hand_target = false
+	_left_hand_grip = null
+	_skeleton = null
+	_hand_bone_idx = -1
+	_enabled = false
+	_left_hand_wrist_target = null
+	_using_wrist_target_fallback = false
+	_middle_finger_bone_idx = -1
+	_wrist_to_palm_local = Vector3.ZERO
+	_current_weight = 0.0
+	_target_weight = 0.0
 
 
 func setup(skeleton: Skeleton3D, config: HandIKConfig = null) -> void:
+	clear()
 	_config = config if config else HandIKConfig.new()
 	_skeleton = skeleton
 	if not is_instance_valid(_skeleton):
 		GlobalLogger.warn("HandIK", "未找到 Skeleton3D，手部 IK 已禁用")
 		return
-	if is_instance_valid(_target_modifier):
-		_target_modifier.queue_free()
-	_target_modifier = null
 	_hand_bone_idx = skeleton.find_bone(_config.tip_bone_name)
 	if _hand_bone_idx == -1:
 		GlobalLogger.warn("HandIK", "未找到手腕骨骼 '%s'，手腕朝向标定不可用" % _config.tip_bone_name)
@@ -62,14 +99,16 @@ func setup(skeleton: Skeleton3D, config: HandIKConfig = null) -> void:
 
 	var node_name := _config.ik_node_name
 	_ik_node = skeleton.get_node_or_null(node_name) as TwoBoneIK3D
-	if not _ik_node:
+	if not _ik_node or _ik_node.setting_count < 1 or _hand_bone_idx < 0:
 		GlobalLogger.warn("HandIK", "Skeleton3D 下未找到 TwoBoneIK3D 节点 '%s'，请在编辑器里添加。" % node_name)
+		clear()
 		return
 
 	# 查找或创建中间目标 Marker3D（固定挂在 Skeleton3D 下，路径稳定）
 	_hand_target = skeleton.get_node_or_null("LeftHandTarget") as Marker3D
 	if not _hand_target:
 		_hand_target = Marker3D.new()
+		_owns_hand_target = true
 		_hand_target.name = "LeftHandTarget"
 		skeleton.add_child(_hand_target)
 		GlobalLogger.info("HandIK", "已自动创建 LeftHandTarget Marker3D")
@@ -85,6 +124,11 @@ func setup(skeleton: Skeleton3D, config: HandIKConfig = null) -> void:
 	skeleton.add_child(_target_modifier)
 	_target_modifier.setup(self)
 	skeleton.move_child(_target_modifier, _ik_node.get_index())
+	_wrist_modifier = HandWristModifier.new()
+	_wrist_modifier.name = "LeftHandWrist"
+	skeleton.add_child(_wrist_modifier)
+	_wrist_modifier.controller = self
+	skeleton.move_child(_wrist_modifier, _ik_node.get_index() + 1)
 	GlobalLogger.info("HandIK", "TwoBoneIK3D '%s' 已绑定，目标点: LeftHandTarget" % node_name)
 
 
@@ -95,7 +139,7 @@ func set_weapon(weapon: BaseWeapon, ik_weight: float = -1.0) -> void:
 	_enabled = false
 	_using_wrist_target_fallback = false
 
-	if not weapon or not _ik_node:
+	if not is_instance_valid(weapon) or not is_instance_valid(_ik_node):
 		GlobalLogger.warn("HandIK", "set_weapon: weapon=%s, ik_node=%s — IK 不启用" % [
 			str(weapon), str(_ik_node)])
 		return
@@ -103,7 +147,7 @@ func set_weapon(weapon: BaseWeapon, ik_weight: float = -1.0) -> void:
 	_current_weapon = weapon
 	_ik_weight = ik_weight if ik_weight >= 0.0 else (_config.default_ik_weight if _config else 1.0)
 	_update_target_weight()
-	_current_weight = _target_weight
+	_current_weight = 0.0
 
 	if weapon.attachment_manager:
 		weapon.attachment_manager.attachments_changed.connect(_on_attachments_changed)
@@ -123,7 +167,7 @@ func set_weapon(weapon: BaseWeapon, ik_weight: float = -1.0) -> void:
 
 
 func _disconnect_weapon_attachments() -> void:
-	if is_instance_valid(_current_weapon) and _current_weapon.attachment_manager:
+	if is_instance_valid(_current_weapon) and is_instance_valid(_current_weapon.attachment_manager):
 		var am := _current_weapon.attachment_manager
 		if am.attachments_changed.is_connected(_on_attachments_changed):
 			am.attachments_changed.disconnect(_on_attachments_changed)
@@ -132,7 +176,7 @@ func _disconnect_weapon_attachments() -> void:
 
 ## 配件变更（换护木/握把等）后握把节点可能被替换，重新查找并更新 IK 目标
 func _on_attachments_changed() -> void:
-	if not _current_weapon:
+	if not is_instance_valid(_current_weapon):
 		return
 	_left_hand_grip = _current_weapon.find_grip_node("LeftHandGrip")
 	_left_hand_wrist_target = _current_weapon.find_grip_node("LeftHandWristTarget")
@@ -168,28 +212,27 @@ func _update_target_weight() -> void:
 	var base := _ik_weight
 	if _is_sprinting:
 		_target_weight = base * (_config.sprint_ik_weight if _config else 0.1)
-	elif _is_running:
-		_target_weight = base * (_config.run_ik_weight if _config else 0.6)
 	elif _is_ads:
 		_target_weight = base * (_config.ads_ik_weight if _config else 0.8)
+	elif _is_running:
+		_target_weight = base * (_config.run_ik_weight if _config else 0.6)
 	else:
 		_target_weight = base * (_config.walk_ik_weight if _config else 1.0)
 
 
 func process_ik(delta: float, active: bool = true) -> void:
-	if not _ik_node:
+	if not is_instance_valid(_ik_node):
 		return
 
 	var can_solve: bool = active and _enabled \
 		and (is_instance_valid(_left_hand_wrist_target) or is_instance_valid(_left_hand_grip)) \
 		and is_instance_valid(_hand_target)
-	if _target_modifier:
+	if is_instance_valid(_target_modifier):
 		_target_modifier.sync_enabled = can_solve
+	if is_instance_valid(_wrist_modifier):
+		_wrist_modifier.active = can_solve
 
-	# 非 SkeletonModifier 更新路径下保留一次同步，确保编辑器和禁用修饰器的
-	# 特殊场景也能工作；正式求解前还会由 HandTargetModifier 再同步一次。
-	if can_solve:
-		_update_hand_target()
+	# Sample only in the modifier chain, after spine aim and before IK.
 
 	var blend_time := maxf(_config.weight_blend_time if _config else 0.12, 0.001)
 	var effective_target := _target_weight if can_solve else 0.0
@@ -203,6 +246,8 @@ func process_ik(delta: float, active: bool = true) -> void:
 
 ## 位置永远取握把；朝向按配置决定是否用标定后的自然手腕姿态。
 func _update_hand_target() -> void:
+	if not is_instance_valid(_skeleton) or not is_instance_valid(_hand_target) or (not is_instance_valid(_left_hand_grip) and not is_instance_valid(_left_hand_wrist_target)):
+		return
 	_refresh_weapon_mount()
 	var target_xf := _get_current_wrist_target_transform()
 	_hand_target.global_transform = target_xf
@@ -284,3 +329,24 @@ class HandTargetModifier extends SkeletonModifier3D:
 	func _process_modification() -> void:
 		if sync_enabled and is_instance_valid(_controller):
 			_controller._update_hand_target()
+
+
+## TwoBoneIK positions the wrist but does not consume the target's orientation.
+class HandWristModifier extends SkeletonModifier3D:
+	var controller: HandIKController
+
+
+	func _process_modification() -> void:
+		if not is_instance_valid(controller) or not is_instance_valid(controller._hand_target):
+			return
+		var skeleton := get_skeleton()
+		var bone := controller._hand_bone_idx
+		if not skeleton or bone < 0:
+			return
+		var parent_basis := skeleton.global_basis.orthonormalized()
+		var parent_idx := skeleton.get_bone_parent(bone)
+		if parent_idx >= 0:
+			parent_basis *= skeleton.get_bone_global_pose(parent_idx).basis.orthonormalized()
+		var desired := (parent_basis.inverse() * controller._hand_target.global_basis.orthonormalized()).get_rotation_quaternion()
+		var current := skeleton.get_bone_pose_rotation(bone)
+		skeleton.set_bone_pose_rotation(bone, current.slerp(desired, clampf(controller._current_weight, 0.0, 1.0)).normalized())

--- a/classes/player/player_camera_controller.gd
+++ b/classes/player/player_camera_controller.gd
@@ -800,21 +800,41 @@ func get_free_yaw_offset() -> float:
 
 
 func get_view_yaw() -> float:
+	if is_instance_valid(_player) and _player.is_ai_player:
+		return _player.rotation.y
 	return _look_controller.get_view_yaw() if is_instance_valid(_look_controller) else 0.0
 
 
 func get_base_view_yaw() -> float:
+	if is_instance_valid(_player) and _player.is_ai_player:
+		return _player.rotation.y
 	return _look_controller.get_base_yaw() if is_instance_valid(_look_controller) else _view_yaw
 
 func get_body_yaw_offset() -> float:
+	if is_instance_valid(_player) and _player.is_ai_player:
+		return 0.0
 	return _look_controller.get_body_yaw_offset() if is_instance_valid(_look_controller) else 0.0
 
 
 func get_visual_body_yaw_offset() -> float:
+	if is_instance_valid(_player) and _player.is_ai_player:
+		return 0.0
 	return _look_controller.get_visual_body_yaw_offset() if is_instance_valid(_look_controller) else get_body_yaw_offset()
 
 func get_view_basis() -> Basis:
+	if is_instance_valid(_player) and _player.is_ai_player:
+		return Basis(Vector3.UP, _player.rotation.y)
 	return _look_controller.get_movement_basis() if is_instance_valid(_look_controller) else Basis(Vector3.UP, _view_yaw)
+
+
+## AI has no active camera, but its procedural skeleton still consumes view state.
+func set_ai_view_angles(yaw: float, pitch: float) -> void:
+	if not is_instance_valid(_player) or not _player.is_ai_player:
+		return
+	_view_yaw = yaw
+	var pitch_limit := _camera_config.max_vertical_angle if _camera_config else 1.4
+	_vertical_angle = clampf(pitch, -pitch_limit, pitch_limit)
+	_body_yaw_blend_remaining = 0.0
 
 
 func _sync_moving_body_yaw() -> void:

--- a/classes/player/spine_aim_controller.gd
+++ b/classes/player/spine_aim_controller.gd
@@ -25,6 +25,7 @@ func setup(
 	_current_pitch = 0.0
 	_current_free_pitch = 0.0
 	_current_free_yaw = 0.0
+	_current_yaw = 0.0
 	if is_instance_valid(_modifier):
 		_modifier.queue_free()
 	_modifier = null
@@ -183,8 +184,7 @@ class SpineAimModifier extends SkeletonModifier3D:
 		if parent_idx != -1:
 			parent_basis = skeleton.get_bone_global_pose(parent_idx).basis.orthonormalized()
 
-		var rest_basis := skeleton.get_bone_rest(bone_idx).basis.orthonormalized()
 		var parent_extra := Quaternion(parent_basis).inverse() * global_extra * Quaternion(parent_basis)
-		var local_extra := Quaternion(rest_basis).inverse() * parent_extra * Quaternion(rest_basis)
 		var current_rotation := skeleton.get_bone_pose_rotation(bone_idx)
-		skeleton.set_bone_pose_rotation(bone_idx, (local_extra * current_rotation).normalized())
+		# Godot 4 bone poses already include the rest orientation and are parent-relative.
+		skeleton.set_bone_pose_rotation(bone_idx, (parent_extra * current_rotation).normalized())

--- a/classes/weapon/base_weapon.gd
+++ b/classes/weapon/base_weapon.gd
@@ -1038,17 +1038,17 @@ func _grip_node_score(node: Node3D) -> float:
 		if parent is AttachmentSlot:
 			var slot := parent as AttachmentSlot
 			if slot.slot_name == "PistolGrip":
-				priority = 100.0
+				priority = maxf(priority, 100.0)
 			elif slot.slot_type == AttachmentSlot.SlotType.PISTOL_GRIP:
-				priority = 100.0
+				priority = maxf(priority, 100.0)
 			elif slot.slot_name == "Underbarrel":
-				priority = 90.0
+				priority = maxf(priority, 90.0)
 			elif slot.slot_type == AttachmentSlot.SlotType.UNDERBARREL:
-				priority = 90.0
+				priority = maxf(priority, 90.0)
 			elif slot.slot_name == "Handguard":
-				priority = 80.0
+				priority = maxf(priority, 80.0)
 			elif slot.slot_type == AttachmentSlot.SlotType.HANDGUARD:
-				priority = 80.0
+				priority = maxf(priority, 80.0)
 		parent = parent.get_parent()
 
 	var local_z := node.position.z

--- a/classes/weapon/recoil_component.gd
+++ b/classes/weapon/recoil_component.gd
@@ -34,8 +34,6 @@ func rebuild_physics() -> void:
 	if not physics_model:
 		physics_model = RecoilPhysicsModel.new()
 	physics_model.rebuild(config, attachment_manager)
-	else:
-		physics_model.rebuild(config, attachment_manager)
 	reset()
 
 

--- a/classes/weapon/weapon_manager.gd
+++ b/classes/weapon/weapon_manager.gd
@@ -3,6 +3,7 @@ extends Node
 
 signal weapon_changed(new_weapon: BaseWeapon)
 signal weapon_fired(weapon: BaseWeapon)
+signal aiming_changed(aiming: bool)
 
 ## 配件装备/卸载后由此信号通知 UI 更新
 signal attachment_equipped(slot_name: String, attachment_name: String)
@@ -163,6 +164,7 @@ func attempt_malfunction_clearance() -> void:
 
 func set_aiming(aiming: bool) -> void:
 	is_aiming = aiming
+	aiming_changed.emit(is_aiming)
 	if _weapon_anim_controller:
 		if aiming:
 			_weapon_anim_controller.play_ads_in()

--- a/tests/ai_aim_check.gd
+++ b/tests/ai_aim_check.gd
@@ -1,0 +1,113 @@
+extends Node
+
+
+func _ready() -> void:
+	_run.call_deferred()
+
+
+func _run() -> void:
+	var map := (load("res://assets/map/TestMap.tscn") as PackedScene).instantiate()
+	get_tree().root.add_child(map)
+	await get_tree().process_frame
+	var player := map.get_node("CharacterBody3D") as BasePlayer
+	var manager := map.get_node("AIPlayerManager") as AIPlayerManager
+	var bot := manager.add_ai_player("AimCheck", BasePlayer.Faction.UA)
+	for i in 180:
+		if bot.is_ai_runtime_ready():
+			break
+		await get_tree().process_frame
+	if not _check(bot.is_ai_runtime_ready() and bot.weapon_manager.current_weapon != null, "staggered AI model and loadout initialization completes"):
+		return
+	var brain := AIPlayerBrain.new()
+	add_child(brain)
+	brain.bot = bot
+	var camera := bot.camera_controller
+	var spine := bot.spine_aim_controller
+	bot.rotation.y = 0.7
+	if not _check(absf(camera.get_body_yaw_offset()) < 0.0001, "spawn/body rotation cannot leave a stale AI view"):
+		return
+
+	# Exercise the brain entry point, not just the view setter.
+	for direction in [Vector3.RIGHT, Vector3.LEFT, Vector3.FORWARD, Vector3.BACK]:
+		brain._face(bot.global_position + direction * 10.0)
+		spine.process_aim(1.0, true)
+		if not _check(absf(camera.get_body_yaw_offset()) < 0.0001, "AI body and view agree after facing " + str(direction)):
+			return
+		if not _check(absf(spine._modifier.yaw_radians) < 0.0001, "AI does not add compensating spine yaw"):
+			return
+		if not _check((-bot.global_basis.z).dot(direction) > 0.999, "body faces commanded heading"):
+			return
+
+	for height in [5.0, -5.0]:
+		brain._face(bot.global_position + Vector3(10, height, 0))
+		spine.process_aim(1.0, true)
+		var expected_pitch := atan2(height, 10.0)
+		if not _check(absf(camera.get_vertical_angle() - expected_pitch) < 0.0001, "AI view retains target elevation"):
+			return
+		if not _check(absf(spine._modifier.pitch_radians - expected_pitch) < 0.001, "target elevation reaches spine aim"):
+			return
+		if not _check(absf(bot.rotation.x) < 0.0001 and absf(bot.rotation.z) < 0.0001, "aiming keeps the character capsule upright"):
+			return
+
+	# Profile aim error must change the coherent aim, not only the body transform.
+	var profile := AIProfile.new()
+	profile.aim_error_degrees = 3.0
+	var pitch_before := camera.get_vertical_angle()
+	for i in 8:
+		brain._apply_aim_error(profile)
+		if not _check(absf(camera.get_body_yaw_offset()) < 0.0001, "aim error keeps body/view synchronized"):
+			return
+		if not _check(absf(camera.get_vertical_angle() - pitch_before) < 0.0001, "yaw error preserves elevation"):
+			return
+
+	# Observe the actual rendered weapon after the spine/attachment modifier chain.
+	# A correct command alone is insufficient if it never moves the muzzle.
+	var weapon := bot.weapon_manager.current_weapon
+	var samples := {}
+	bot.hand_ik_controller._target_modifier.modification_processed.connect(
+		func(): samples["direction"] = weapon._get_muzzle_direction()
+	)
+	brain._face(bot.global_position + Vector3(0, 0, -10))
+	spine.process_aim(1.0, true)
+	for i in 3:
+		await get_tree().process_frame
+	if not _check(samples.has("direction"), "weapon direction is sampled after pose modification"):
+		return
+	var level_direction: Vector3 = samples.direction
+	brain._face(bot.global_position + Vector3(0, 5, -10))
+	spine.process_aim(1.0, true)
+	for i in 3:
+		await get_tree().process_frame
+	var elevated_direction: Vector3 = samples.direction
+	if not _check(elevated_direction.y > level_direction.y + 0.1, "elevated aim raises the actual muzzle direction"):
+		return
+	brain._move_to(bot.global_position + Vector3(10, 3, 0), profile, 0.016)
+	if not _check(absf(camera.get_vertical_angle()) < 0.0001, "navigation restores a level heading"):
+		return
+
+	var local_view := player.camera_controller.get_view_yaw()
+	if not _check(not player.set_ai_aim_direction(Vector3.RIGHT), "AI commands cannot take over a local player"):
+		return
+	if not _check(is_equal_approx(local_view, player.camera_controller.get_view_yaw()), "local view is unchanged"):
+		return
+	if not _check(not bot.set_ai_aim_direction(Vector3.ZERO), "zero aim does not reset heading"):
+		return
+	bot.is_ragdolled = true
+	if not _check(not bot.set_ai_aim_direction(Vector3.RIGHT), "ragdoll ignores aim commands"):
+		return
+	bot.is_ragdolled = false
+	if not _check(bot.set_ai_aim_direction(Vector3.UP), "vertical target has a valid aim"):
+		return
+	spine.process_aim(1.0, true)
+	if not _check(is_equal_approx(spine._modifier.pitch_radians, deg_to_rad(spine._config.max_look_up_degrees)), "vertical aim respects spine limit"):
+		return
+	print("ai_aim_check=ok muzzle_y_delta=%.3f" % (elevated_direction.y - level_direction.y))
+	get_tree().quit(0)
+
+
+func _check(condition: bool, message: String) -> bool:
+	if condition:
+		return true
+	push_error(message)
+	get_tree().quit(1)
+	return false

--- a/tests/ai_aim_check.tscn
+++ b/tests/ai_aim_check.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://tests/ai_aim_check.gd" id="1"]
+
+[node name="AIAimCheck" type="Node"]
+script = ExtResource("1")

--- a/tests/ik_regression_check.gd
+++ b/tests/ik_regression_check.gd
@@ -1,0 +1,183 @@
+extends Node
+
+var failures := 0
+var wrist_samples := 0
+var wrist_error := 0.0
+
+
+func _ready() -> void:
+	_run.call_deferred()
+
+
+func _check(ok: bool, message: String) -> void:
+	if not ok:
+		failures += 1
+		push_error(message)
+
+
+func _run() -> void:
+	var map := (load("res://assets/map/TestMap.tscn") as PackedScene).instantiate()
+	get_tree().root.add_child(map)
+	for i in 10:
+		await get_tree().physics_frame
+	var player := map.get_node("CharacterBody3D") as BasePlayer
+	var hand := player.hand_ik_controller
+	var foot := player.foot_ik_controller
+	var skeleton := player.model_manager.skeleton
+	_check(foot._left_ik != null and foot._right_ik != null, "default model supplies both foot solvers")
+	_check(foot._left_target != null and foot._right_target != null, "default model supplies both foot targets")
+	_check(foot._pose_modifier.get_index() < foot._left_ik.get_index() and foot._pose_modifier.get_index() < foot._right_ik.get_index(), "animated feet sampled before both solvers")
+	for solver in [foot._left_ik, foot._right_ik]:
+		_check(solver.get_root_bone(0) >= 0 and solver.get_middle_bone(0) >= 0 and solver.get_end_bone(0) >= 0, "authored leg chain resolves")
+		_check(solver.get_node_or_null(solver.get_target_node(0)) != null, "foot target path resolves")
+		_check(solver.get_node_or_null(solver.get_pole_node(0)) != null, "knee pole path resolves")
+
+	hand.set_movement_state(false, false)
+	player.weapon_manager.set_aiming(true)
+	_check(hand._is_ads and is_equal_approx(hand._target_weight, hand._ik_weight * hand._config.ads_ik_weight), "ADS signal selects configured IK weight")
+	hand.set_movement_state(true, false)
+	_check(is_equal_approx(hand._target_weight, hand._ik_weight * hand._config.ads_ik_weight), "ADS takes precedence over running")
+	player.weapon_manager.set_aiming(false)
+	_check(not hand._is_ads and is_equal_approx(hand._target_weight, hand._ik_weight * hand._config.run_ik_weight), "leaving ADS restores movement weight")
+
+	# Observe the real engine modifier chain at full influence.
+	var saved_config := hand._config
+	hand._config = saved_config.duplicate()
+	hand._config.walk_ik_weight = 1.0
+	hand._config.run_ik_weight = 1.0
+	hand._config.ads_ik_weight = 1.0
+	hand._config.wrist_rotation_offset = Vector3(35, 70, -20)
+	hand._ik_weight = 1.0
+	hand.set_movement_state(false, false)
+	hand.process_ik(1.0)
+	hand._wrist_modifier.modification_processed.connect(func():
+		var actual := (skeleton.global_basis.orthonormalized() * skeleton.get_bone_global_pose(hand._hand_bone_idx).basis.orthonormalized()).get_rotation_quaternion()
+		var desired := hand._hand_target.global_basis.orthonormalized().get_rotation_quaternion()
+		if hand._current_weight > 0.999:
+			wrist_samples += 1
+			wrist_error = maxf(wrist_error, actual.angle_to(desired))
+	)
+	for i in 30:
+		await get_tree().process_frame
+	_check(wrist_samples > 0 and wrist_error < 0.002, "wrist orientation reaches target after arm solve")
+	hand._config = saved_config
+	_test_rotation_spaces()
+	_test_grip_priority()
+
+	# Freeze animation and use an explicit pose so swing/contact assertions are deterministic.
+	player.set_process(false)
+	player.set_physics_process(false)
+	player.animation_controller._animation_tree.active = false
+	foot.set_active(false)
+	# Upstream uses authored wrist targets instead of automatic calibration.
+	var authored_target := hand._left_hand_wrist_target
+	_check(is_instance_valid(authored_target), "default weapon has an authored wrist target")
+	hand._left_hand_grip = null
+	hand._update_hand_target()
+	_check(hand._hand_target.global_transform.is_equal_approx(authored_target.global_transform), "wrist-only weapons preserve the authored target transform")
+	hand._on_attachments_changed()
+	_check(is_instance_valid(hand._left_hand_grip) and hand._left_hand_wrist_target == authored_target, "attachment update refreshes grip and wrist references")
+	hand._config = saved_config
+	# Exercise the actual TwoBoneIK implementation, not just target calculations.
+	skeleton.reset_bone_poses()
+	for side in ["left", "right"]:
+		var solver: TwoBoneIK3D = foot.get("_%s_ik" % side)
+		var target: Marker3D = foot.get("_%s_target" % side)
+		var tip: int = foot.get("_%s_foot_idx" % side)
+		target.global_position = skeleton.global_transform * skeleton.get_bone_global_pose(tip).origin + Vector3.UP * 0.06
+		solver.influence = 1.0
+		var errors: Array[float] = []
+		solver.modification_processed.connect(func():
+			errors.append((skeleton.global_transform * skeleton.get_bone_global_pose(tip).origin).distance_to(target.global_position))
+		, CONNECT_ONE_SHOT)
+		await get_tree().process_frame
+		await get_tree().process_frame
+		_check(not errors.is_empty() and errors[0] < 0.005, "%s leg solver reaches raised ground target" % side)
+		solver.influence = 0.0
+	var bone := foot._left_foot_idx
+	skeleton.reset_bone_poses()
+	var hit := {"colliding": true, "point": Vector3.ZERO, "normal": Vector3.UP}
+	var blend := foot._update_leg(foot._left_ik, foot._left_target, bone, hit, 0.0, 1.0, true)
+	_check(is_equal_approx(blend, 1.0), "planted foot acquires ground contact")
+	_check(is_equal_approx(foot._left_target.global_position.y, FootIKController.ANKLE_OFFSET), "planted target includes ankle clearance")
+	var parent := skeleton.get_bone_parent(bone)
+	var parent_world := skeleton.global_basis * skeleton.get_bone_global_pose(parent).basis
+	skeleton.set_bone_pose_position(bone, skeleton.get_bone_pose_position(bone) + parent_world.inverse() * Vector3.UP * 0.2)
+	blend = foot._update_leg(foot._left_ik, foot._left_target, bone, hit, 1.0, 0.016, true)
+	_check(is_zero_approx(blend) and is_zero_approx(foot._left_ik.influence), "lifted swing foot immediately releases ground IK")
+	skeleton.reset_bone_poses()
+	blend = foot._update_leg(foot._left_ik, foot._left_target, bone, hit, 1.0, 1.0, false)
+	_check(is_zero_approx(blend), "airborne body releases foot IK")
+	foot._left_ik.influence = 0.8
+	foot._right_ik.influence = 0.8
+	foot._left_blend = 0.8
+	foot._right_blend = 0.8
+	foot.set_active(false, 0.016)
+	_check(foot._left_ik.influence > 0.0 and foot._left_ik.influence < 0.8, "prone transition retains gradual foot fade")
+	player.is_ragdolled = true
+	player._process(0.016)
+	_check(foot._left_ik.influence == 0.0 and foot._right_ik.influence == 0.0 and not foot._ankle_modifier.active, "ragdoll gate immediately clears both feet and ankles")
+	player.is_ragdolled = false
+	player._process(0.016)
+	_check(foot._pose_modifier.active and foot._ankle_modifier.active, "leaving ragdoll re-enables foot updates")
+	foot.set_active(false)
+
+	var old_solver := hand._ik_node
+	var old_sync := hand._target_modifier
+	old_solver.influence = 0.65
+	hand.setup(null, saved_config)
+	_check(old_solver.influence == 0.0 and not old_sync.active and hand._ik_node == null, "failed model bind disables old hand chain")
+	hand.setup(skeleton, saved_config)
+	hand.setup(skeleton, saved_config)
+	_check(skeleton.get_node_or_null("LeftHandWrist") == hand._wrist_modifier, "repeated model binding replaces modifiers without duplicates")
+	player.model_manager.model_unloaded.emit()
+	_check(hand._ik_node == null and foot._left_ik == null, "model unload clears both controllers")
+	print("ik_regression_check=%s failures=%d wrist_samples=%d wrist_error_deg=%.4f" % ["ok" if failures == 0 else "FAILED", failures, wrist_samples, rad_to_deg(wrist_error)])
+	get_tree().quit(0 if failures == 0 else 1)
+
+
+func _test_rotation_spaces() -> void:
+	var skeleton := Skeleton3D.new()
+	add_child(skeleton)
+	skeleton.rotation = Vector3(0.2, 0.7, -0.1)
+	skeleton.add_bone("parent")
+	skeleton.add_bone("child")
+	skeleton.set_bone_parent(1, 0)
+	skeleton.set_bone_rest(0, Transform3D(Basis.from_euler(Vector3(0.3, -0.4, 0.2)), Vector3.ZERO))
+	skeleton.set_bone_rest(1, Transform3D(Basis.from_euler(Vector3(-0.6, 0.1, 0.8)), Vector3.UP))
+	skeleton.reset_bone_poses()
+	var spine := SpineAimController.SpineAimModifier.new()
+	skeleton.add_child(spine)
+	var before := skeleton.get_bone_global_pose(1).basis.get_rotation_quaternion()
+	var delta := Quaternion(Vector3.RIGHT, deg_to_rad(30.0))
+	spine._apply_global_rotation(skeleton, 1, delta)
+	var actual := skeleton.get_bone_global_pose(1).basis.get_rotation_quaternion()
+	_check(actual.angle_to(delta * before) < 0.002, "spine applies skeleton-space rotation with nonidentity bone rests")
+	skeleton.reset_bone_poses()
+	var ankle := FootIKController.FootAnkleModifier.new()
+	skeleton.add_child(ankle)
+	before = (skeleton.global_basis * skeleton.get_bone_global_pose(1).basis).get_rotation_quaternion()
+	var normal := Vector3(0.25, 1.0, 0.15).normalized()
+	delta = Quaternion(Vector3.UP.cross(normal).normalized(), Vector3.UP.angle_to(normal) * 0.6)
+	ankle._apply_ankle_rotation(1, normal, 0.6)
+	actual = (skeleton.global_basis * skeleton.get_bone_global_pose(1).basis).get_rotation_quaternion()
+	_check(actual.angle_to(delta * before) < 0.002, "ankle applies world-space tilt with rotated skeleton and bone rests")
+	skeleton.queue_free()
+
+
+func _test_grip_priority() -> void:
+	var weapon := BaseWeapon.new()
+	var handguard := AttachmentSlot.new()
+	handguard.slot_type = AttachmentSlot.SlotType.HANDGUARD
+	weapon.add_child(handguard)
+	var grip := Marker3D.new()
+	grip.name = "LeftHandGrip"
+	handguard.add_child(grip)
+	var underbarrel := AttachmentSlot.new()
+	underbarrel.slot_type = AttachmentSlot.SlotType.UNDERBARREL
+	handguard.add_child(underbarrel)
+	var nested_grip := Marker3D.new()
+	nested_grip.name = "LeftHandGrip"
+	underbarrel.add_child(nested_grip)
+	_check(weapon._grip_node_score(nested_grip) > weapon._grip_node_score(grip), "nested underbarrel grip outranks ancestor handguard")
+	weapon.free()

--- a/tests/ik_regression_check.tscn
+++ b/tests/ik_regression_check.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://tests/ik_regression_check.gd" id="1"]
+
+[node name="IKRegressionCheck" type="Node"]
+script = ExtResource("1")

--- a/tests/recoil_physics_test.gd
+++ b/tests/recoil_physics_test.gd
@@ -19,7 +19,7 @@ static func run_all() -> Dictionary:
 		assert(results[key], key)
 	return results
 
-static func _model(cfg: WeaponConfig):
+static func _model(cfg: WeaponConfig) -> RecoilPhysicsModel:
 	var model = RECOIL_MODEL_SCRIPT.new()
 	model.rebuild(cfg, null)
 	return model
@@ -61,4 +61,5 @@ static func _pose_snapshot_has_six_dof_state() -> bool:
 	component.initialize(_base_config())
 	component.apply_recoil()
 	var pose := component.get_pose_snapshot()
+	component.free()
 	return pose.has("pitch_rad") and pose.has("yaw_rad") and pose.has("roll_rad") and pose.has("position_local") and pose.has("velocity_local") and pose.has("angular_velocity")


### PR DESCRIPTION
AI body turns could leave procedural aim stale, while hand orientation, ADS weights, nested grips, and foot contact/lifecycle handling produced incorrect IK poses. This change keeps bot yaw and elevation coherent, applies wrist orientation after the arm solve, fixes spine rotation space, and releases lifted feet and ragdolls correctly.

- Preserve the current branch's authored wrist targets, foot chains, animated knee poles, separate look controller, and prone foot fade.
- Connect aiming state to hand IK, preserve nested attachment priority, and clear obsolete hand/foot bindings on unload or failed replacement.
- Sample animated feet before the leg solvers, with physics-tick ground probes and parent-relative ankle rotation.
- Add regression scenes for AI aim and IK, including final modifier output and staggered bot initialization.

A separate prerequisite commit removes a misplaced `else` in upstream's recoil component, which prevented player scripts from compiling. It also adds the recoil test helper's missing return type and frees its temporary component.

Validation on Godot 4.7, headless with `--fixed-fps 60`:

- `tests/ik_regression_check.tscn`: passed, zero failures.
- `tests/ai_aim_check.tscn`: passed; elevated aiming increases actual muzzle direction Y by 0.326.
- `tests/headless_debug_api_runner.tscn`: all 24 checks passed.
- `git diff --check`: passed.

Known validation limitation: the existing recoil suite now parses but fails its `off_axis_bore_produces_yaw_and_roll` assertion. No recoil physics behavior was changed to mask that failure. Visual terrain and animation playtesting remains outstanding.
